### PR TITLE
fix: covid academic years off

### DIFF
--- a/src/student_success_tool/analysis/pdp/constants.py
+++ b/src/student_success_tool/analysis/pdp/constants.py
@@ -1,12 +1,12 @@
 DEFAULT_MIN_PASSING_GRADE = "1"
 DEFAULT_COURSE_LEVEL_PATTERN = r"^(?P<course_level>\d)\d{2}(?:[A-Z]{,2})?$"
 DEFAULT_PEAK_COVID_TERMS = {
-    ("2020-21", "SPRING"),
-    ("2020-21", "SUMMER"),
-    ("2021-22", "FALL"),
-    ("2021-22", "WINTER"),
-    ("2021-22", "SPRING"),
-    ("2021-22", "SUMMER"),
+    ("2019-20", "SPRING"), # Spring 2020
+    ("2019-20", "SUMMER"), # Summer 2020
+    ("2020-21", "FALL"), # Fall 2020
+    ("2020-21", "WINTER"), # Winter 2020/2021
+    ("2020-21", "SPRING"), # Spring 2021
+    ("2020-21", "SUMMER"), # Summer 2021
 }
 
 NUM_COURSE_FEATURE_COL_PREFIX = "num_courses"


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->
I believe the default COVID academic years are off. Check my thinking here, but Spring 2020 is actually the academic year 2019-2020, and so on.

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
