### PR TITLE
Improve handling for term/year features

### DIFF
--- a/src/student_success_tool/analysis/pdp/README.md
+++ b/src/student_success_tool/analysis/pdp/README.md
@@ -42,7 +42,6 @@
     df_student_terms = pdp.dataops.make_student_term_dataset(
         df_cohort,
         df_course,
-        institution_state="VT",
         min_passing_grade="1",
         key_course_subject_areas=[24, 51],
     )

--- a/src/student_success_tool/analysis/pdp/dataops.py
+++ b/src/student_success_tool/analysis/pdp/dataops.py
@@ -16,7 +16,7 @@ def make_student_term_dataset(
     min_passing_grade: str = constants.DEFAULT_MIN_PASSING_GRADE,
     course_level_pattern: str = constants.DEFAULT_COURSE_LEVEL_PATTERN,
     peak_covid_terms: set[tuple[str, str]] = constants.DEFAULT_PEAK_COVID_TERMS,
-    key_course_subject_areas: t.Optional[list[int]] = None,
+    key_course_subject_areas: t.Optional[list[str]] = None,
     key_course_ids: t.Optional[list[str]] = None,
 ) -> pd.DataFrame:
     """

--- a/src/student_success_tool/analysis/pdp/dataops.py
+++ b/src/student_success_tool/analysis/pdp/dataops.py
@@ -174,9 +174,9 @@ def clean_up_labeled_dataset_cols_and_vals(df: pd.DataFrame) -> pd.DataFrame:
                 "institution_id",
                 "term_id",
                 "academic_year",
-                "academic_term",
+                # "academic_term",  # keeping this to see if useful
                 "cohort",
-                "cohort_term",
+                # "cohort_term",  # keeping this to see if useful
                 "term_rank",
                 "term_rank_fall_spring",
                 "term_course_begin_date_min",

--- a/src/student_success_tool/analysis/pdp/dataops.py
+++ b/src/student_success_tool/analysis/pdp/dataops.py
@@ -90,15 +90,6 @@ def standardize_cohort_dataset(df: pd.DataFrame) -> pd.DataFrame:
                 "naspa_first_generation",
                 # redundant
                 "attendance_status_term_1",
-                # derived directly from course dataset
-                "number_of_credits_attempted_year_1",
-                "number_of_credits_attempted_year_2",
-                "number_of_credits_attempted_year_3",
-                "number_of_credits_attempted_year_4",
-                "number_of_credits_earned_year_1",
-                "number_of_credits_earned_year_2",
-                "number_of_credits_earned_year_3",
-                "number_of_credits_earned_year_4",
                 # covered indirectly by course dataset fields/features
                 "gateway_math_status",
                 "gateway_english_status",

--- a/src/student_success_tool/analysis/pdp/dataops.py
+++ b/src/student_success_tool/analysis/pdp/dataops.py
@@ -12,7 +12,6 @@ def make_student_term_dataset(
     df_cohort: pd.DataFrame,
     df_course: pd.DataFrame,
     *,
-    institution_state: t.Optional[str] = None,
     min_passing_grade: str = constants.DEFAULT_MIN_PASSING_GRADE,
     course_level_pattern: str = constants.DEFAULT_COURSE_LEVEL_PATTERN,
     peak_covid_terms: set[tuple[str, str]] = constants.DEFAULT_PEAK_COVID_TERMS,
@@ -27,8 +26,6 @@ def make_student_term_dataset(
     Args:
         df_cohort: As output by :func:`dataio.read_raw_pdp_cohort_data_from_file()` .
         df_course: As output by :func:`dataio.read_raw_pdp_course_data_from_file()` .
-        institution_state: **DEPRECATED** Standard, 2-letter abbreviation for the state
-            in which the cohort institution is located.
         min_passing_grade: Minimum numeric grade considered by institution as "passing".
         course_level_pattern
         peak_covid_terms
@@ -37,7 +34,7 @@ def make_student_term_dataset(
     """
     df_students = (
         df_cohort.pipe(standardize_cohort_dataset)
-        .pipe(features.student.add_features, institution_state=institution_state)
+        .pipe(features.student.add_features)
     )  # fmt: skip
     df_courses_plus = (
         df_course.pipe(standardize_course_dataset)

--- a/src/student_success_tool/analysis/pdp/features/shared.py
+++ b/src/student_success_tool/analysis/pdp/features/shared.py
@@ -9,9 +9,9 @@ def extract_short_cip_code(ser: pd.Series) -> pd.Series:
     # NOTE: this simpler form works, but the values aren't nearly as clean
     # return ser.str.slice(stop=2).str.strip(".")
     return (
-        ser.str.extract(r"^(?P<study_group>\d[\d.])[\d.]+$", expand=False)
+        ser.str.extract(r"^(?P<subject_area>\d[\d.])[\d.]+$", expand=False)
         .str.strip(".")
-        .astype("Int8")
+        .astype("string")
     )
 
 

--- a/src/student_success_tool/analysis/pdp/features/shared.py
+++ b/src/student_success_tool/analysis/pdp/features/shared.py
@@ -15,6 +15,15 @@ def extract_short_cip_code(ser: pd.Series) -> pd.Series:
     )
 
 
+def frac_credits_earned(
+    df: pd.DataFrame,
+    *,
+    earned_col: str = "num_credits_earned",
+    attempted_col: str = "num_credits_attempted",
+) -> pd.Series:
+    return df[earned_col].div(df[attempted_col])
+
+
 def compute_values_equal(ser: pd.Series, to: t.Any | list[t.Any]) -> pd.Series:
     return ser.isin(to) if isinstance(to, list) else ser.eq(to)
 

--- a/src/student_success_tool/analysis/pdp/features/student.py
+++ b/src/student_success_tool/analysis/pdp/features/student.py
@@ -8,9 +8,6 @@ from . import shared
 
 LOGGER = logging.getLogger(__name__)
 
-# TODO: rename feature?
-# student_program_of_study_changed_first_year => student_program_of_study_changed_year_1
-
 
 def add_features(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -33,13 +30,13 @@ def add_features(df: pd.DataFrame) -> pd.DataFrame:
             "student_program_of_study_area_year_1": ft.partial(
                 student_program_of_study_area, col="program_of_study_year_1"
             ),
-            "student_program_of_study_changed_first_year": ft.partial(
-                student_program_of_study_changed_first_year,
+            "student_program_of_study_changed_term_1_to_year_1": ft.partial(
+                student_program_of_study_changed_term_1_to_year_1,
                 term_col="program_of_study_term_1",
                 year_col="program_of_study_year_1",
             ),
-            "student_program_of_study_area_changed_first_year": ft.partial(
-                student_program_of_study_changed_first_year,
+            "student_program_of_study_area_changed_term_1_to_year_1": ft.partial(
+                student_program_of_study_changed_term_1_to_year_1,
                 term_col="student_program_of_study_area_term_1",
                 year_col="student_program_of_study_area_year_1",
             ),
@@ -52,7 +49,7 @@ def student_program_of_study_area(df: pd.DataFrame, *, col: str) -> pd.Series:
     return shared.extract_short_cip_code(df[col])
 
 
-def student_program_of_study_changed_first_year(
+def student_program_of_study_changed_term_1_to_year_1(
     df: pd.DataFrame, *, term_col: str, year_col: str
 ) -> pd.Series:
     return df[term_col].ne(df[year_col]).astype("boolean")

--- a/src/student_success_tool/analysis/pdp/features/student.py
+++ b/src/student_success_tool/analysis/pdp/features/student.py
@@ -26,16 +26,6 @@ def add_features(
     """
     LOGGER.info("adding student features ...")
     feature_name_funcs: dict[str, t.Callable[[pd.DataFrame], pd.Series]] = {
-        # NOTE: it's likely that this the "most recent" enrollments info
-        # comes from "the future" wrt predictions, so we can't include as model features
-        # holding space here in case PDP tells us otherwise!
-        # "student_has_prior_enrollment_at_other_inst": ft.partial(
-        #     student_has_prior_enrollment_at_other_inst
-        # ),
-        # "student_prior_enrollment_at_other_inst_was_in_state": ft.partial(
-        #     student_prior_enrollment_at_other_inst_was_in_state,
-        #     institution_state=institution_state,
-        # ),
         "student_program_of_study_area_term_1": ft.partial(
             student_program_of_study_area, col="program_of_study_term_1"
         ),
@@ -60,23 +50,6 @@ def add_features(
             "diff_gpa_term_1_to_year_1": ft.partial(diff_gpa_term_1_to_year_1),
         }
     return df.assign(**feature_name_funcs)
-
-
-def student_has_prior_enrollment_at_other_inst(
-    df: pd.DataFrame,
-    *,
-    col: str = "most_recent_last_enrollment_at_other_institution_state",
-) -> pd.Series:
-    return df[col].astype("string").notna()
-
-
-def student_prior_enrollment_at_other_inst_was_in_state(
-    df: pd.DataFrame,
-    *,
-    col: str = "most_recent_last_enrollment_at_other_institution_state",
-    institution_state: str,
-) -> pd.Series:
-    return df[col].astype("string").eq(institution_state).astype("boolean")
 
 
 def student_program_of_study_area(df: pd.DataFrame, *, col: str) -> pd.Series:

--- a/src/student_success_tool/analysis/pdp/features/student.py
+++ b/src/student_success_tool/analysis/pdp/features/student.py
@@ -12,17 +12,13 @@ LOGGER = logging.getLogger(__name__)
 # student_program_of_study_changed_first_year => student_program_of_study_changed_year_1
 
 
-def add_features(
-    df: pd.DataFrame, *, institution_state: t.Optional[str] = None
-) -> pd.DataFrame:
+def add_features(df: pd.DataFrame) -> pd.DataFrame:
     """
     Compute student-level features from a standardized cohort dataset,
     and add as columns to ``df`` .
 
     Args:
         df
-        institution_state: **DEPRECATED** Standard, 2-letter abbreviation for the state
-            in which the cohort institution is located.
     """
     LOGGER.info("adding student features ...")
     feature_name_funcs: dict[str, t.Callable[[pd.DataFrame], pd.Series]] = {

--- a/src/student_success_tool/analysis/pdp/features/student.py
+++ b/src/student_success_tool/analysis/pdp/features/student.py
@@ -1,6 +1,5 @@
 import functools as ft
 import logging
-import typing as t
 
 import pandas as pd
 
@@ -18,31 +17,25 @@ def add_features(df: pd.DataFrame) -> pd.DataFrame:
         df
     """
     LOGGER.info("adding student features ...")
-    feature_name_funcs: dict[str, t.Callable[[pd.DataFrame], pd.Series]] = {
-        "student_program_of_study_area_term_1": ft.partial(
+    return df.assign(
+        student_program_of_study_area_term_1=ft.partial(
             student_program_of_study_area, col="program_of_study_term_1"
         ),
-    }
-    # in case of num_terms_checkin == 1, these features can't be computed
-    # bc a necessary raw column gets dropped in the standardize function
-    if "program_of_study_year_1" in df.columns:
-        feature_name_funcs |= {
-            "student_program_of_study_area_year_1": ft.partial(
-                student_program_of_study_area, col="program_of_study_year_1"
-            ),
-            "student_program_of_study_changed_term_1_to_year_1": ft.partial(
-                student_program_of_study_changed_term_1_to_year_1,
-                term_col="program_of_study_term_1",
-                year_col="program_of_study_year_1",
-            ),
-            "student_program_of_study_area_changed_term_1_to_year_1": ft.partial(
-                student_program_of_study_changed_term_1_to_year_1,
-                term_col="student_program_of_study_area_term_1",
-                year_col="student_program_of_study_area_year_1",
-            ),
-            "diff_gpa_term_1_to_year_1": ft.partial(diff_gpa_term_1_to_year_1),
-        }
-    return df.assign(**feature_name_funcs)
+        student_program_of_study_area_year_1=ft.partial(
+            student_program_of_study_area, col="program_of_study_year_1"
+        ),
+        student_program_of_study_changed_term_1_to_year_1=ft.partial(
+            student_program_of_study_changed_term_1_to_year_1,
+            term_col="program_of_study_term_1",
+            year_col="program_of_study_year_1",
+        ),
+        student_program_of_study_area_changed_term_1_to_year_1=ft.partial(
+            student_program_of_study_changed_term_1_to_year_1,
+            term_col="student_program_of_study_area_term_1",
+            year_col="student_program_of_study_area_year_1",
+        ),
+        diff_gpa_term_1_to_year_1=ft.partial(diff_gpa_term_1_to_year_1),
+    )
 
 
 def student_program_of_study_area(df: pd.DataFrame, *, col: str) -> pd.Series:

--- a/src/student_success_tool/analysis/pdp/features/student.py
+++ b/src/student_success_tool/analysis/pdp/features/student.py
@@ -17,6 +17,10 @@ def add_features(df: pd.DataFrame) -> pd.DataFrame:
         df
     """
     LOGGER.info("adding student features ...")
+    # in case somebody drops some/all years, check for which years are present in df
+    credits_years = [
+        yr for yr in (1, 2, 3, 4) if f"number_of_credits_earned_year_{yr}" in df.columns
+    ]
     return df.assign(
         student_program_of_study_area_term_1=ft.partial(
             student_program_of_study_area, col="program_of_study_term_1"
@@ -35,6 +39,14 @@ def add_features(df: pd.DataFrame) -> pd.DataFrame:
             year_col="student_program_of_study_area_year_1",
         ),
         diff_gpa_term_1_to_year_1=ft.partial(diff_gpa_term_1_to_year_1),
+        **{
+            f"frac_credits_earned_year_{yr}": ft.partial(
+                shared.frac_credits_earned,
+                earned_col=f"number_of_credits_earned_year_{yr}",
+                attempted_col=f"number_of_credits_attempted_year_{yr}",
+            )
+            for yr in credits_years
+        },
     )
 
 

--- a/src/student_success_tool/analysis/pdp/features/student_term.py
+++ b/src/student_success_tool/analysis/pdp/features/student_term.py
@@ -14,7 +14,7 @@ def aggregate_from_course_level_features(
     df: pd.DataFrame,
     *,
     student_term_id_cols: list[str],
-    key_course_subject_areas: t.Optional[list[int]] = None,
+    key_course_subject_areas: t.Optional[list[str]] = None,
     key_course_ids: t.Optional[list[str]] = None,
 ) -> pd.DataFrame:
     """

--- a/src/student_success_tool/analysis/pdp/features/student_term.py
+++ b/src/student_success_tool/analysis/pdp/features/student_term.py
@@ -96,16 +96,14 @@ def aggregate_from_course_level_features(
         ("core_course", "Y"),
         ("course_type", ["CC", "CD"]),
         ("enrolled_at_other_institution_s", "Y"),
-        ("grade", ["0", "1", "F", "W"])
+        ("grade", ["0", "1", "F", "W"]),
     ]
     if key_course_subject_areas is not None:
         agg_col_vals.extend(
             ("course_subject_area", kcsa) for kcsa in key_course_subject_areas
         )
     if key_course_ids is not None:
-        agg_col_vals.extend(
-            ("course_id", kc) for kc in key_course_ids
-        )
+        agg_col_vals.extend(("course_id", kc) for kc in key_course_ids)
     df_val_equals = sum_val_equal_cols_by_group(
         df, grp_cols=student_term_id_cols, agg_col_vals=agg_col_vals
     )

--- a/src/student_success_tool/analysis/pdp/features/student_term.py
+++ b/src/student_success_tool/analysis/pdp/features/student_term.py
@@ -135,8 +135,8 @@ def add_features(df: pd.DataFrame) -> pd.DataFrame:
     feature_name_funcs = (
         {
             "year_of_enrollment_at_cohort_inst": year_of_enrollment_at_cohort_inst,
-            "frac_credits_earned": frac_credits_earned,
             "term_is_while_student_enrolled_at_other_inst": term_is_while_student_enrolled_at_other_inst,
+            "frac_credits_earned": shared.frac_credits_earned,
         }
         | {
             fc_col: ft.partial(compute_frac_courses, numer_col=nc_col)
@@ -180,15 +180,6 @@ def year_of_enrollment_at_cohort_inst(
         .astype("Int16")["cohort_yr"]
         + 1
     )
-
-
-def frac_credits_earned(
-    df: pd.DataFrame,
-    *,
-    earned_col: str = "num_credits_earned",
-    attempted_col: str = "num_credits_attempted",
-) -> pd.Series:
-    return df[earned_col].div(df[attempted_col])
 
 
 # TODO: we could probably compute this directly, w/o an intermediate feature?

--- a/src/student_success_tool/analysis/pdp/schemas/base.py
+++ b/src/student_success_tool/analysis/pdp/schemas/base.py
@@ -277,13 +277,13 @@ class RawPDPCohortDataSchema(pda.DataFrameModel):
     )
     retention: pt.Series["boolean"]
     persistence: pt.Series["boolean"]
-    years_to_bachelors_at_cohort_inst: pt.Series["int32"] = YearsToOfField()
-    years_to_associates_or_certificate_at_cohort_inst: pt.Series["int32"] = (
-        YearsToOfField()
+    years_to_bachelors_at_cohort_inst: pt.Series["Int8"] = YearsToOfField(nullable=True)
+    years_to_associates_or_certificate_at_cohort_inst: pt.Series["Int8"] = (
+        YearsToOfField(nullable=True)
     )
-    years_to_bachelor_at_other_inst: pt.Series["int32"] = YearsToOfField()
-    years_to_associates_or_certificate_at_other_inst: pt.Series["int32"] = (
-        YearsToOfField()
+    years_to_bachelor_at_other_inst: pt.Series["Int8"] = YearsToOfField(nullable=True)
+    years_to_associates_or_certificate_at_other_inst: pt.Series["Int8"] = (
+        YearsToOfField(nullable=True)
     )
     years_of_last_enrollment_at_cohort_institution: pt.Series["int32"] = (
         YearsToOfField()
@@ -408,6 +408,10 @@ class RawPDPCohortDataSchema(pda.DataFrameModel):
         return series.cat.set_categories(["Y", "N"])
 
     @pda.parser(
+        "years_to_associates_or_certificate_at_cohort_inst",
+        "years_to_bachelors_at_cohort_inst",
+        "years_to_associates_or_certificate_at_other_inst",
+        "years_to_bachelor_at_other_inst",
         "first_year_to_associates_or_certificate_at_cohort_inst",
         "first_year_to_bachelors_at_cohort_inst",
         "first_year_to_associates_or_certificate_at_other_inst",

--- a/src/student_success_tool/analysis/pdp/schemas/base.py
+++ b/src/student_success_tool/analysis/pdp/schemas/base.py
@@ -316,13 +316,17 @@ class RawPDPCohortDataSchema(pda.DataFrameModel):
     foreign_language_completion: t.Optional[pt.Series["string"]] = pda.Field(
         nullable=True
     )
-    first_year_to_bachelors_at_cohort_inst: pt.Series["int32"] = YearsToOfField()
-    first_year_to_associates_or_certificate_at_cohort_inst: pt.Series["int32"] = (
-        YearsToOfField()
+    first_year_to_bachelors_at_cohort_inst: pt.Series["Int8"] = YearsToOfField(
+        nullable=True
     )
-    first_year_to_bachelor_at_other_inst: pt.Series["int32"] = YearsToOfField()
-    first_year_to_associates_or_certificate_at_other_inst: pt.Series["int32"] = (
-        YearsToOfField()
+    first_year_to_associates_or_certificate_at_cohort_inst: pt.Series["Int8"] = (
+        YearsToOfField(nullable=True)
+    )
+    first_year_to_bachelor_at_other_inst: pt.Series["Int8"] = YearsToOfField(
+        nullable=True
+    )
+    first_year_to_associates_or_certificate_at_other_inst: pt.Series["Int8"] = (
+        YearsToOfField(nullable=True)
     )
     program_of_study_year_1: pt.Series["string"] = pda.Field(nullable=True)
     most_recent_bachelors_at_other_institution_state: pt.Series["string"] = pda.Field(
@@ -402,6 +406,15 @@ class RawPDPCohortDataSchema(pda.DataFrameModel):
     @pda.parser("disability_status")
     def set_disability_status_categories(cls, series):
         return series.cat.set_categories(["Y", "N"])
+
+    @pda.parser(
+        "first_year_to_associates_or_certificate_at_cohort_inst",
+        "first_year_to_bachelors_at_cohort_inst",
+        "first_year_to_associates_or_certificate_at_other_inst",
+        "first_year_to_bachelor_at_other_inst",
+    )
+    def set_zero_year_values_to_null(cls, series):
+        return series.mask(series.eq(0), pd.NA).astype("Int8")
 
     class Config:
         coerce = True

--- a/src/student_success_tool/generation/pdp/raw_cohort.py
+++ b/src/student_success_tool/generation/pdp/raw_cohort.py
@@ -344,8 +344,8 @@ class Provider(BaseProvider):
     def persistence(self) -> bool:
         return self.generator.pybool()  # type: ignore
 
-    def _years_to_of(self) -> int:
-        return self.random_int(min=0, max=7)
+    def _years_to_of(self, min_value: int = 0, max_value: int = 7) -> int:
+        return self.random_int(min=min_value, max=max_value)
 
     def years_to_bachelors_at_cohort_inst(self) -> int:
         return self._years_to_of()

--- a/tests/analysis/pdp/features/test_course.py
+++ b/tests/analysis/pdp/features/test_course.py
@@ -34,7 +34,7 @@ from student_success_tool.analysis.pdp.features import course
                     "delivery_method": ["O", "H", "F"],
                     "grade": ["4", "1", "W"],
                     "course_id": ["MATH101", "MATH202", "PHYS303"],
-                    "course_subject_area": [40, 45, 3],
+                    "course_subject_area": ["40", "45", "03"],
                     "course_passed": [True, False, pd.NA],
                     "course_completed": [True, True, False],
                     "course_level": [1, 2, 3],

--- a/tests/analysis/pdp/features/test_shared.py
+++ b/tests/analysis/pdp/features/test_shared.py
@@ -3,25 +3,26 @@ import pytest
 
 from student_success_tool.analysis.pdp.features import shared
 
+
 @pytest.mark.parametrize(
-        ["ser", "to", "exp"],
-        [
-            (
-                pd.Series(["0", "1", "2", "3", "4"]),
-                "0",
-                pd.Series([True, False, False, False, False])
-            ),
-            (
-                pd.Series(["0", "1", "2", "3", "4"]),
-                ["0","1","F","W"],
-                pd.Series([True, True, False, False, False])
-            )
-        ]
+    ["ser", "to", "exp"],
+    [
+        (
+            pd.Series(["0", "1", "2", "3", "4"]),
+            "0",
+            pd.Series([True, False, False, False, False]),
+        ),
+        (
+            pd.Series(["0", "1", "2", "3", "4"]),
+            ["0", "1", "F", "W"],
+            pd.Series([True, True, False, False, False]),
+        ),
+    ],
 )
 def test_compute_values_equal(ser, to, exp):
     obs = shared.compute_values_equal(ser, to)
     assert isinstance(obs, pd.Series) and not obs.empty
-    assert obs.dtype == 'bool'
+    assert obs.dtype == "bool"
     assert obs.equals(exp) or obs.compare(exp).empty
 
 

--- a/tests/analysis/pdp/features/test_shared.py
+++ b/tests/analysis/pdp/features/test_shared.py
@@ -23,3 +23,27 @@ def test_compute_values_equal(ser, to, exp):
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.dtype == 'bool'
     assert obs.equals(exp) or obs.compare(exp).empty
+
+
+@pytest.mark.parametrize(
+    ["df", "earned_col", "attempted_col", "exp"],
+    [
+        (
+            pd.DataFrame(
+                {
+                    "nc_earned": [5.0, 7.5, 6.0, 0.0],
+                    "nc_attempted": [10.0, 7.5, 8.0, 15.0],
+                }
+            ),
+            "nc_earned",
+            "nc_attempted",
+            pd.Series([0.5, 1.0, 0.75, 0.0]),
+        ),
+    ],
+)
+def test_frac_credits_earned(df, earned_col, attempted_col, exp):
+    obs = shared.frac_credits_earned(
+        df, earned_col=earned_col, attempted_col=attempted_col
+    )
+    assert isinstance(obs, pd.Series) and not obs.empty
+    assert obs.equals(exp) or obs.compare(exp).empty

--- a/tests/analysis/pdp/features/test_student.py
+++ b/tests/analysis/pdp/features/test_student.py
@@ -15,6 +15,8 @@ from student_success_tool.analysis.pdp.features import student
                     "program_of_study_year_1": ["24.0101", "27.05"],
                     "gpa_group_term_1": [4.00, 3.00],
                     "gpa_group_year_1": [3.5, 3.5],
+                    "number_of_credits_attempted_year_1": [15.0, 12.0],
+                    "number_of_credits_earned_year_1": [12.0, 12.0],
                 }
             ),
             pd.DataFrame(
@@ -24,6 +26,8 @@ from student_success_tool.analysis.pdp.features import student
                     "program_of_study_year_1": ["24.0101", "27.05"],
                     "gpa_group_term_1": [4.00, 3.00],
                     "gpa_group_year_1": [3.5, 3.5],
+                    "number_of_credits_attempted_year_1": [15.0, 12.0],
+                    "number_of_credits_earned_year_1": [12.0, 12.0],
                     "student_program_of_study_area_term_1": [24, 27],
                     "student_program_of_study_area_year_1": [24, 27],
                     "student_program_of_study_changed_term_1_to_year_1": [False, True],
@@ -32,6 +36,7 @@ from student_success_tool.analysis.pdp.features import student
                         False,
                     ],
                     "diff_gpa_term_1_to_year_1": [-0.5, 0.5],
+                    "frac_credits_earned_year_1": [0.8, 1.0],
                 }
             ),
         ),

--- a/tests/analysis/pdp/features/test_student.py
+++ b/tests/analysis/pdp/features/test_student.py
@@ -5,7 +5,7 @@ from student_success_tool.analysis.pdp.features import student
 
 
 @pytest.mark.parametrize(
-    ["df", "institution_state", "exp"],
+    ["df", "exp"],
     [
         (
             pd.DataFrame(
@@ -17,7 +17,6 @@ from student_success_tool.analysis.pdp.features import student
                     "gpa_group_year_1": [3.5, 3.5],
                 }
             ),
-            "VT",
             pd.DataFrame(
                 {
                     "student_guid": ["123", "456"],
@@ -33,26 +32,10 @@ from student_success_tool.analysis.pdp.features import student
                 }
             ),
         ),
-        (
-            pd.DataFrame(
-                {
-                    "student_guid": ["123", "456"],
-                    "program_of_study_term_1": ["24.0101", "27.01"],
-                }
-            ),
-            "VT",
-            pd.DataFrame(
-                {
-                    "student_guid": ["123", "456"],
-                    "program_of_study_term_1": ["24.0101", "27.01"],
-                    "student_program_of_study_area_term_1": [24, 27],
-                }
-            ),
-        ),
     ],
 )
-def test_add_student_features(df, institution_state, exp):
-    obs = student.add_features(df, institution_state=institution_state)
+def test_add_student_features(df, exp):
+    obs = student.add_features(df)
     assert isinstance(obs, pd.DataFrame) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
 

--- a/tests/analysis/pdp/features/test_student.py
+++ b/tests/analysis/pdp/features/test_student.py
@@ -28,8 +28,8 @@ from student_success_tool.analysis.pdp.features import student
                     "gpa_group_year_1": [3.5, 3.5],
                     "number_of_credits_attempted_year_1": [15.0, 12.0],
                     "number_of_credits_earned_year_1": [12.0, 12.0],
-                    "student_program_of_study_area_term_1": [24, 27],
-                    "student_program_of_study_area_year_1": [24, 27],
+                    "student_program_of_study_area_term_1": ["24", "27"],
+                    "student_program_of_study_area_year_1": ["24", "27"],
                     "student_program_of_study_changed_term_1_to_year_1": [False, True],
                     "student_program_of_study_area_changed_term_1_to_year_1": [
                         False,
@@ -54,7 +54,7 @@ def test_add_student_features(df, exp):
         (
             pd.DataFrame({"program_cip": ["240012.0", "519999", "9.1000", "X"]}),
             "program_cip",
-            pd.Series([24, 51, 9, pd.NA], dtype="Int8"),
+            pd.Series(["24", "51", "9", pd.NA], dtype="string"),
         ),
     ],
 )

--- a/tests/analysis/pdp/features/test_student.py
+++ b/tests/analysis/pdp/features/test_student.py
@@ -26,8 +26,11 @@ from student_success_tool.analysis.pdp.features import student
                     "gpa_group_year_1": [3.5, 3.5],
                     "student_program_of_study_area_term_1": [24, 27],
                     "student_program_of_study_area_year_1": [24, 27],
-                    "student_program_of_study_changed_first_year": [False, True],
-                    "student_program_of_study_area_changed_first_year": [False, False],
+                    "student_program_of_study_changed_term_1_to_year_1": [False, True],
+                    "student_program_of_study_area_changed_term_1_to_year_1": [
+                        False,
+                        False,
+                    ],
                     "diff_gpa_term_1_to_year_1": [-0.5, 0.5],
                 }
             ),
@@ -73,8 +76,8 @@ def test_student_program_of_study_area(df, col, exp):
         ),
     ],
 )
-def test_student_program_of_study_changed_first_year(df, term_col, year_col, exp):
-    obs = student.student_program_of_study_changed_first_year(
+def test_student_program_of_study_changed_term_1_to_year_1(df, term_col, year_col, exp):
+    obs = student.student_program_of_study_changed_term_1_to_year_1(
         df, term_col=term_col, year_col=year_col
     )
     assert isinstance(obs, pd.Series) and not obs.empty

--- a/tests/analysis/pdp/features/test_student.py
+++ b/tests/analysis/pdp/features/test_student.py
@@ -15,10 +15,6 @@ from student_success_tool.analysis.pdp.features import student
                     "program_of_study_year_1": ["24.0101", "27.05"],
                     "gpa_group_term_1": [4.00, 3.00],
                     "gpa_group_year_1": [3.5, 3.5],
-                    "most_recent_last_enrollment_at_other_institution_state": [
-                        "VT",
-                        "PA",
-                    ],
                 }
             ),
             "VT",
@@ -29,15 +25,6 @@ from student_success_tool.analysis.pdp.features import student
                     "program_of_study_year_1": ["24.0101", "27.05"],
                     "gpa_group_term_1": [4.00, 3.00],
                     "gpa_group_year_1": [3.5, 3.5],
-                    "most_recent_last_enrollment_at_other_institution_state": [
-                        "VT",
-                        "PA",
-                    ],
-                    # "student_has_prior_enrollment_at_other_inst": [True, True],
-                    # "student_prior_enrollment_at_other_inst_was_in_state": [
-                    #     True,
-                    #     False,
-                    # ],
                     "student_program_of_study_area_term_1": [24, 27],
                     "student_program_of_study_area_year_1": [24, 27],
                     "student_program_of_study_changed_first_year": [False, True],
@@ -51,10 +38,6 @@ from student_success_tool.analysis.pdp.features import student
                 {
                     "student_guid": ["123", "456"],
                     "program_of_study_term_1": ["24.0101", "27.01"],
-                    "most_recent_last_enrollment_at_other_institution_state": [
-                        "VT",
-                        pd.NA,
-                    ],
                 }
             ),
             "VT",
@@ -62,15 +45,6 @@ from student_success_tool.analysis.pdp.features import student
                 {
                     "student_guid": ["123", "456"],
                     "program_of_study_term_1": ["24.0101", "27.01"],
-                    "most_recent_last_enrollment_at_other_institution_state": [
-                        "VT",
-                        pd.NA,
-                    ],
-                    # "student_has_prior_enrollment_at_other_inst": [True, False],
-                    # "student_prior_enrollment_at_other_inst_was_in_state": [
-                    #     True,
-                    #     pd.NA,
-                    # ],
                     "student_program_of_study_area_term_1": [24, 27],
                 }
             ),

--- a/tests/analysis/pdp/features/test_student_term.py
+++ b/tests/analysis/pdp/features/test_student_term.py
@@ -185,30 +185,6 @@ def test_year_of_enrollment_at_cohort_inst(df, ccol, acol, exp):
 
 
 @pytest.mark.parametrize(
-    ["df", "earned_col", "attempted_col", "exp"],
-    [
-        (
-            pd.DataFrame(
-                {
-                    "nc_earned": [5.0, 7.5, 6.0, 0.0],
-                    "nc_attempted": [10.0, 7.5, 8.0, 15.0],
-                }
-            ),
-            "nc_earned",
-            "nc_attempted",
-            pd.Series([0.5, 1.0, 0.75, 0.0]),
-        ),
-    ],
-)
-def test_frac_credits_earned(df, earned_col, attempted_col, exp):
-    obs = student_term.frac_credits_earned(
-        df, earned_col=earned_col, attempted_col=attempted_col
-    )
-    assert isinstance(obs, pd.Series) and not obs.empty
-    assert obs.equals(exp) or obs.compare(exp).empty
-
-
-@pytest.mark.parametrize(
     ["df", "numer_col", "denom_col", "exp"],
     [
         (

--- a/tests/analysis/pdp/features/test_student_term.py
+++ b/tests/analysis/pdp/features/test_student_term.py
@@ -98,7 +98,11 @@ def test_sum_dummy_cols_by_group(df, grp_cols, agg_cols, exp):
                 }
             ),
             ["student_guid", "term_id"],
-            [("course_type", ["CC", "CD"]), ("course_level", 0), ("grade", ["0", "1", "F", "W"])],
+            [
+                ("course_type", ["CC", "CD"]),
+                ("course_level", 0),
+                ("grade", ["0", "1", "F", "W"]),
+            ],
             pd.DataFrame(
                 {
                     "student_guid": ["123", "123", "456", "789"],

--- a/tests/analysis/pdp/test_dataops.py
+++ b/tests/analysis/pdp/test_dataops.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -134,5 +135,92 @@ def test_standardize_cohort_dataset(df, exp):
 )
 def test_standardize_course_dataset(df, exp):
     obs = dataops.standardize_course_dataset(df)
+    assert isinstance(obs, pd.DataFrame) and not obs.empty
+    assert obs.equals(exp) or obs.compare(exp).empty
+
+
+@pytest.mark.parametrize(
+    ["df", "exp"],
+    [
+        (
+            pd.DataFrame(
+                {
+                    "year_of_enrollment_at_cohort_inst": [1, 2, 3, 4],
+                    "term_id": [
+                        "2020-21 FALL",
+                        "2020-21 WINTER",
+                        "2020-21 SPRING",
+                        "2020-21 SUMMER",
+                    ],
+                    "course_ids": [
+                        ["X101", "Y101"],
+                        ["X102", "Y101", "Z201"],
+                        ["X101", "Y102"],
+                        ["X101", "Y101", "X102", "Y202", "Z101"],
+                    ],
+                    "retention": [False, True, True, True],
+                    "first_year_to_associates_or_certificate_at_cohort_inst": [
+                        pd.NA,
+                        2,
+                        2,
+                        5,
+                    ],
+                    "first_year_to_bachelors_at_cohort_inst": [pd.NA, pd.NA, 4, 3],
+                    "first_year_to_associates_or_certificate_at_other_inst": [
+                        4,
+                        1,
+                        5,
+                        3,
+                    ],
+                    "first_year_to_bachelor_at_other_inst": [pd.NA, pd.NA, pd.NA, 6],
+                    "frac_credits_earned_year_1": [1.0, 0.5, 0.75, 0.9],
+                    "frac_credits_earned_year_2": [0.9, 0.75, 0.8, 0.85],
+                }
+            ).astype(
+                {
+                    "first_year_to_associates_or_certificate_at_cohort_inst": "Int8",
+                    "first_year_to_bachelors_at_cohort_inst": "Int8",
+                    "first_year_to_associates_or_certificate_at_other_inst": "Int8",
+                    "first_year_to_bachelor_at_other_inst": "Int8",
+                }
+            ),
+            pd.DataFrame(
+                {
+                    "year_of_enrollment_at_cohort_inst": [1, 2, 3, 4],
+                    "first_year_to_associates_or_certificate_at_cohort_inst": [
+                        pd.NA,
+                        pd.NA,
+                        2,
+                        pd.NA,
+                    ],
+                    "first_year_to_bachelors_at_cohort_inst": [pd.NA, pd.NA, pd.NA, 3],
+                    "first_year_to_associates_or_certificate_at_other_inst": [
+                        pd.NA,
+                        1,
+                        pd.NA,
+                        3,
+                    ],
+                    "first_year_to_bachelor_at_other_inst": [
+                        pd.NA,
+                        pd.NA,
+                        pd.NA,
+                        pd.NA,
+                    ],
+                    "frac_credits_earned_year_1": [np.nan, 0.5, 0.75, 0.9],
+                    "frac_credits_earned_year_2": [np.nan, np.nan, 0.8, 0.85],
+                }
+            ).astype(
+                {
+                    "first_year_to_associates_or_certificate_at_cohort_inst": "Int8",
+                    "first_year_to_bachelors_at_cohort_inst": "Int8",
+                    "first_year_to_associates_or_certificate_at_other_inst": "Int8",
+                    "first_year_to_bachelor_at_other_inst": "Int8",
+                }
+            ),
+        ),
+    ],
+)
+def test_clean_up_labeled_dataset_cols_and_vals(df, exp):
+    obs = dataops.clean_up_labeled_dataset_cols_and_vals(df)
     assert isinstance(obs, pd.DataFrame) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty

--- a/tests/analysis/pdp/test_dataops.py
+++ b/tests/analysis/pdp/test_dataops.py
@@ -41,7 +41,7 @@ def test_infer_num_terms_in_year(series, exp):
 
 
 @pytest.mark.parametrize(
-    ["df", "num_terms_checkin", "exp"],
+    ["df", "exp"],
     [
         (
             pd.DataFrame(
@@ -59,35 +59,18 @@ def test_infer_num_terms_in_year(series, exp):
                     "gpa_group_year_1": [3.0, 4.0],
                 }
             ),
-            None,
             pd.DataFrame(
                 {
                     "cohort": ["2024-25", "2023-24"],
                     "cohort_term": ["FALL", "SPRING"],
                     "gpa_group_year_1": [3.0, 4.0],
-                }
-            ),
-        ),
-        (
-            pd.DataFrame(
-                {
-                    "cohort": ["2024-25", "2023-24"],
-                    "cohort_term": ["FALL", "SPRING"],
-                    "gpa_group_year_1": [3.0, 4.0],
-                }
-            ),
-            1,
-            pd.DataFrame(
-                {
-                    "cohort": ["2024-25", "2023-24"],
-                    "cohort_term": ["FALL", "SPRING"],
                 }
             ),
         ),
     ],
 )
-def test_standardize_cohort_dataset(df, num_terms_checkin, exp):
-    obs = dataops.standardize_cohort_dataset(df, num_terms_checkin=num_terms_checkin)
+def test_standardize_cohort_dataset(df, exp):
+    obs = dataops.standardize_cohort_dataset(df)
     assert isinstance(obs, pd.DataFrame) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
 

--- a/tests/analysis/pdp/test_dataops.py
+++ b/tests/analysis/pdp/test_dataops.py
@@ -57,12 +57,15 @@ def test_infer_num_terms_in_year(series, exp):
                     "number_of_credits_earned_year_1": [10.0, 5.0],
                     "gateway_math_status": ["R", "N"],
                     "gpa_group_year_1": [3.0, 4.0],
+                    "most_recent_bachelors_at_other_institution_state": ["VT", "IL"],
                 }
             ),
             pd.DataFrame(
                 {
                     "cohort": ["2024-25", "2023-24"],
                     "cohort_term": ["FALL", "SPRING"],
+                    "number_of_credits_attempted_year_1": [10.0, 5.0],
+                    "number_of_credits_earned_year_1": [10.0, 5.0],
                     "gpa_group_year_1": [3.0, 4.0],
                 }
             ),


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- removed hacky "num terms checkin" logic from student-term dataset functionality, and replaced it with a more general solution: a "cleanup" function applied to labeled data that dynamically nulls out values coming from years in the future (after the student-term used for prediction) to prevent data leakage
- as a result, included a few extra features that were previously dropped, including the fraction of credits earned year-by-year
- in order for new logic to work, renamed a few features to have a consistent "*_year_X" naming scheme
- also, added a parser to the base pdp cohort dataset schema that nullifies 0 values for "first year to *" fields, which are now included as features
- finally, fixed a bug in a couple CIP-based features that resulted in them being interpreted as numeric values rather than categorical (**note:** this is a minor breaking change)

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

Still struggling to train a model with performance I'd consider sufficient. Truly grasping at straws. Got any more features to try? I'm all ears!

Also, re: schema change: https://datakind.slack.com/archives/C07KBDVCFUZ/p1729642107713779

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- The logic for nullifying "future" values is a bit tricky. The corresponding unit test makes me more confident it's doing what I want, but please look carefully at this and convince yourself: Is this logic correct?