### PR TITLE
[PDP] Finish grade feature generalization

### DIFF
--- a/src/student_success_tool/analysis/pdp/dataops.py
+++ b/src/student_success_tool/analysis/pdp/dataops.py
@@ -193,6 +193,7 @@ def clean_up_labeled_dataset_cols_and_vals(df: pd.DataFrame) -> pd.DataFrame:
                 "term_course_begin_date_min",
                 "term_course_end_date_max",
                 # columns used to derive other features, but not features themselves
+                "grade",
                 "course_ids",
                 "course_subjects",
                 "course_subject_areas",

--- a/src/student_success_tool/analysis/pdp/features/course.py
+++ b/src/student_success_tool/analysis/pdp/features/course.py
@@ -42,6 +42,7 @@ def add_features(
         course_completed=course_completed,
         course_level=ft.partial(course_level, pattern=course_level_pattern),
         course_grade_numeric=course_grade_numeric,
+        course_grade=course_grade,
     )
 
 
@@ -92,6 +93,36 @@ def course_level(
 
 def course_grade_numeric(df: pd.DataFrame, *, col: str = "grade") -> pd.Series:
     return df[col].mask(df[col].isin(NON_NUMERIC_GRADES), pd.NA).astype("Float32")
+
+
+def course_grade(
+    df: pd.DataFrame,
+    *,
+    grade_col: str = "grade",
+    grade_num_col: str = "course_grade_numeric",
+) -> pd.Series:
+    non_numeric_grades = (
+        df[grade_col]
+        .mask(~df[grade_col].isin(NON_NUMERIC_GRADES), pd.NA)
+        # frustratingly, pdp uses "A" grade to indicate "Audit", which is just begging
+        # for confusion with the usual meaning of an "A" grade :/
+        # let's replace it with "AUD" for clarity, and so we can safely combine
+        # non-numeric grades with derived letter grades below
+        .replace("A", value="AUD")
+        .astype("string")
+    )
+    letter_grades = pd.cut(
+        df[grade_num_col],
+        # pandas' binning args here are bad if you want (standard!) left-inclusive bins
+        # and *labels* for those bins; despite appearances, binning is like so:
+        # [0, 0.7) => F, [0.7, 1.7) => D, [1.7, 2.7) => C, [2.7, 3.7) => B, [3.7, 4.0] => A
+        bins=[0.0, 0.69, 1.69, 2.69, 3.69, 4.01],
+        labels=["F", "D", "C", "B", "A"],
+        right=True,
+        include_lowest=True,
+    ).astype("string")
+    # NOTE: this assumes that "F" ("Fail") grades are equivalent to "F" letter grades
+    return non_numeric_grades.combine_first(letter_grades)
 
 
 def _grade_is_passing(grade: str, min_passing_grade: float) -> bool | None:

--- a/src/student_success_tool/analysis/pdp/features/course.py
+++ b/src/student_success_tool/analysis/pdp/features/course.py
@@ -106,9 +106,11 @@ def course_grade(
         .mask(~df[grade_col].isin(NON_NUMERIC_GRADES), pd.NA)
         # frustratingly, pdp uses "A" grade to indicate "Audit", which is just begging
         # for confusion with the usual meaning of an "A" grade :/
-        # let's replace it with "AUD" for clarity, and so we can safely combine
+        # let's replace it with "AUDIT" for clarity, and so we can safely combine
         # non-numeric grades with derived letter grades below
-        .replace("A", value="AUD")
+        .replace("A", value="AUDIT")
+        # similarly, "O" looks like "0", so let's replace with "OTHER" for clarity
+        .replace("O", value="OTHER")
         .astype("string")
     )
     letter_grades = pd.cut(

--- a/src/student_success_tool/analysis/pdp/features/student_term.py
+++ b/src/student_success_tool/analysis/pdp/features/student_term.py
@@ -93,7 +93,7 @@ def aggregate_from_course_level_features(
             "course_instructor_employment_status",
             "course_instructor_rank",
             "course_level",
-            "grade",  # TODO: only if this is actually categorical
+            "course_grade",
         ],
     )
 

--- a/tests/analysis/pdp/features/test_course.py
+++ b/tests/analysis/pdp/features/test_course.py
@@ -183,7 +183,7 @@ def test_course_grade_numeric(df, col, exp):
             ).astype({"grade": "string", "grade_num": "Float32"}),
             "grade",
             "grade_num",
-            pd.Series(["A", "B", "I", "W", "B", "D", "F", "AUD"], dtype="string"),
+            pd.Series(["A", "B", "I", "W", "B", "D", "F", "AUDIT"], dtype="string"),
         ),
     ],
 )

--- a/tests/analysis/pdp/features/test_course.py
+++ b/tests/analysis/pdp/features/test_course.py
@@ -39,6 +39,7 @@ from student_success_tool.analysis.pdp.features import course
                     "course_completed": [True, True, False],
                     "course_level": [1, 2, 3],
                     "course_grade_numeric": [4.0, 1.0, pd.NA],
+                    "course_grade": ["A", "D", "W"],
                 }
             ).astype({"course_passed": "boolean", "course_grade_numeric": "Float32"}),
         ),
@@ -155,5 +156,38 @@ def test_course_level(df, col, pattern, exp):
 )
 def test_course_grade_numeric(df, col, exp):
     obs = course.course_grade_numeric(df, col=col)
+    assert isinstance(obs, pd.Series) and not obs.empty
+    assert obs.equals(exp) or obs.compare(exp).empty
+
+
+@pytest.mark.parametrize(
+    ["df", "grade_col", "grade_num_col", "exp"],
+    [
+        (
+            pd.DataFrame(
+                {
+                    "grade": ["4", "2", "P", "F", "1"],
+                    "grade_num": [4.0, 2.0, pd.NA, pd.NA, 1.0],
+                },
+            ).astype({"grade": "string", "grade_num": "Float32"}),
+            "grade",
+            "grade_num",
+            pd.Series(["A", "C", "P", "F", "D"], dtype="string"),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "grade": ["4.0", "3.3", "I", "W", "2.7", "0.7", "0.0", "A"],
+                    "grade_num": [4.0, 3.3, pd.NA, pd.NA, 2.7, 0.7, 0.0, pd.NA],
+                }
+            ).astype({"grade": "string", "grade_num": "Float32"}),
+            "grade",
+            "grade_num",
+            pd.Series(["A", "B", "I", "W", "B", "D", "F", "AUD"], dtype="string"),
+        ),
+    ],
+)
+def test_course_grade(df, grade_col, grade_num_col, exp):
+    obs = course.course_grade(df, grade_col=grade_col, grade_num_col=grade_num_col)
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds a course feature that computes a (categorical) grade value by converting numeric grades into classic "letter" grades
- replaces the raw grade with this categorical one where appropriate

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

This was the last piece needed to fully move away from assuming raw PDP grade values were categoricals. This _happened_ to be the case for HACC, and it also worked albeit differently for MSU, but the PDP spec specifically allows for numeric grades to take continuous values between 0.0 and 4.0. This last piece ensures that we can handle all of these cases with the same featurization code.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- Any objections to requiring numeric grades (i.e. the `"course_grade_numeric"` col) as inputs here, in addition to the raw grade? I could simplify the inputs and just recompute the numeric grade, since it's a lightweight operation, but I was on the fence about duplicative calculations.