### PR TITLE
[CI] Update uv and enable PyPI publish step

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v3
       with:
-        version: "0.5.02"
+        version: "0.5.2"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
     - name: Install project and dependencies

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v3
       with:
-        version: "0.4.29"
+        version: "0.5.02"
         enable-cache: true
         cache-dependency-glob: "uv.lock"
     - name: Install project and dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,10 +24,10 @@ jobs:
       #     user: __token__
       #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
       #     repository_url: https://test.pypi.org/legacy/
-      # - name: Publish package to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_API_TOKEN }}
-      #     verify_metadata: true
-      #     verbose: true
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verify-metadata: true
+          verbose: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,14 @@ jobs:
       - name: Build package
         run: |
           uv build --python "3.10"
-      # TODO: set up publishing secrets or trusted publisher
-      # - name: Publish package to TestPyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      #     repository_url: https://test.pypi.org/legacy/
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          verify-metadata: true
+          verbose: true
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- bumps version of `uv` used in GH workflows ([release notes](https://github.com/astral-sh/uv/releases) if curious)
- enables publish package to PyPI GH workflow step, after adding necessary repo secret

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

This is a prerequisite to publishing a v0.1 of this package to PyPI.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- How strongly do folks feel about publishing to "test PyPI" before doing an official release? It's a helpful way to catch errors before you make a very public mistake, but not strictly necessary.