### PR TITLE
[pdp] Add column associations EDA func

### DIFF
--- a/src/student_success_tool/analysis/pdp/eda.py
+++ b/src/student_success_tool/analysis/pdp/eda.py
@@ -147,6 +147,24 @@ def compute_pairwise_associations(
     ref_col: t.Optional[str] = None,
     exclude_cols: t.Optional[str | list[str]] = None,
 ) -> pd.DataFrame:
+    """
+    Compute pairwise associations between all columns and each other or, instead,
+    all columns and a specified reference column.
+
+    Per-pair association metrics depend on the data types of each:
+
+        - nominal-nominal => Cramer's V
+        - numeric-numeric => Spearman rank correlation
+        - nominal-numeric => Correlation ratio
+
+    Args:
+        df
+        ref_col: Reference column against which associations are to be computed.
+            If None, all pairwise associations are computed.
+        exclude_cols: One or multiple columns to exclude from computing associations;
+            for example, if values are unique identifiers or all a single value,
+            making their associations irrelevant.
+    """
     # cast datetime columns to numeric, boolean to string
     df = df.assign(
         **{
@@ -202,8 +220,11 @@ def compute_pairwise_associations(
 
 def cramers_v(s1: pd.Series, s2: pd.Series) -> float | None:
     """
-    Compute Cramer's V statistic for categorical-categorical association,
+    Compute Cramer's V statistic for nominal-nominal association,
     which is symmetric -- i.e. V(x, y) == V(y, x).
+
+    References:
+        - https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V
 
     See Also:
         - :func:`scipy.stats.contingency.association()`
@@ -226,7 +247,10 @@ def cramers_v(s1: pd.Series, s2: pd.Series) -> float | None:
 
 def correlation_ratio(s1: pd.Series, s2: pd.Series) -> float:
     """
-    Compute the Correlation Ratio for categorical-numeric association.
+    Compute the Correlation Ratio for nominal-numeric association.
+
+    References:
+        - https://en.wikipedia.org/wiki/Correlation_ratio
 
     Note:
         ``s1`` and ``s2`` are automatically detected as being categorical or numeric,

--- a/src/student_success_tool/analysis/pdp/eda.py
+++ b/src/student_success_tool/analysis/pdp/eda.py
@@ -164,6 +164,10 @@ def compute_pairwise_associations(
         exclude_cols: One or multiple columns to exclude from computing associations;
             for example, if values are unique identifiers or all a single value,
             making their associations irrelevant.
+
+    References:
+        - https://en.wikipedia.org/wiki/Cram%C3%A9r%27s_V
+        - https://en.wikipedia.org/wiki/Correlation_ratio
     """
     # cast datetime columns to numeric, boolean to string
     df = df.assign(
@@ -200,12 +204,12 @@ def compute_pairwise_associations(
         elif col1 in single_value_cols or col2 in single_value_cols:  # n/a
             assoc = None
         elif col1 in nominal_cols and col2 in nominal_cols:  # nom-nom
-            assoc = cramers_v(df[col1], df[col2])
+            assoc = _cramers_v(df[col1], df[col2])
             is_symmetric = True
         elif (col1 in nominal_cols and col2 in numeric_cols) or (
             col1 in numeric_cols and col2 in nominal_cols
         ):  # nom-num
-            assoc = correlation_ratio(df[col1], df[col2])
+            assoc = _correlation_ratio(df[col1], df[col2])
         else:  # num-num
             assoc = df[col1].corr(df[col2], method="spearman")
             is_symmetric = True
@@ -218,7 +222,7 @@ def compute_pairwise_associations(
     return df_assoc
 
 
-def cramers_v(s1: pd.Series, s2: pd.Series) -> float | None:
+def _cramers_v(s1: pd.Series, s2: pd.Series) -> float | None:
     """
     Compute Cramer's V statistic for nominal-nominal association,
     which is symmetric -- i.e. V(x, y) == V(y, x).
@@ -245,7 +249,7 @@ def cramers_v(s1: pd.Series, s2: pd.Series) -> float | None:
         return None
 
 
-def correlation_ratio(s1: pd.Series, s2: pd.Series) -> float:
+def _correlation_ratio(s1: pd.Series, s2: pd.Series) -> float:
     """
     Compute the Correlation Ratio for nominal-numeric association.
 

--- a/tests/analysis/pdp/test_eda.py
+++ b/tests/analysis/pdp/test_eda.py
@@ -1,0 +1,79 @@
+import pandas as pd
+import pytest
+
+from student_success_tool.analysis.pdp import eda
+
+
+@pytest.mark.parametrize(
+    ["df", "ref_col", "exclude_cols", "exp"],
+    [
+        (
+            pd.DataFrame(
+                {"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [3.0, 2.0, 1.0]}
+            ),
+            None,
+            None,
+            pd.DataFrame(
+                data=[[1.0, 1.0, -1.0], [1.0, 1.0, -1.0], [-1.0, -1.0, 1.0]],
+                index=["col1", "col2", "col3"],
+                columns=["col1", "col2", "col3"],
+                dtype="Float32",
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "col1": [1, 2, 3],
+                    "col2": [2.0, 2.5, 3.0],
+                    "col3": ["A", "A", "B"],
+                    "col4": ["X", "Y", "X"],
+                }
+            ),
+            None,
+            None,
+            pd.DataFrame(
+                data=[
+                    [1.0, 1.0, 0.866025, 0.0],
+                    [1.0, 1.0, 0.866025, 0.0],
+                    [0.866025, 0.866025, 1.0, 0.5],
+                    [0.0, 0.0, 0.5, 1.0],
+                ],
+                index=["col1", "col2", "col3", "col4"],
+                columns=["col1", "col2", "col3", "col4"],
+                dtype="Float32",
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [3.0, 2.0, 1.0]}
+            ),
+            "col3",
+            None,
+            pd.DataFrame(
+                data=[-1.0, -1.0, 1.0],
+                index=["col1", "col2", "col3"],
+                columns=["col3"],
+                dtype="Float32",
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {"col1": [1, 2, 3], "col2": [2, 3, 4], "col3": [3.0, 2.0, 1.0]}
+            ),
+            None,
+            "col3",
+            pd.DataFrame(
+                data=[[1.0, 1.0], [1.0, 1.0]],
+                index=["col1", "col2"],
+                columns=["col1", "col2"],
+                dtype="Float32",
+            ),
+        ),
+    ],
+)
+def test_compute_pairwise_associations(df, ref_col, exclude_cols, exp):
+    obs = eda.compute_pairwise_associations(
+        df, ref_col=ref_col, exclude_cols=exclude_cols
+    )
+    assert isinstance(obs, pd.DataFrame)
+    assert pd.testing.assert_frame_equal(obs, exp) is None


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds `compute_pairwise_associations()` function to `eda` module, which is a more generic equivalent to `DataFrame.corr()` that handles nominal-nominal and nominal-numeric column pairs in addition to the usual numeric-numeric
- adds unit tests for said function

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

I needed a way to compute associations for more data types, since PDP has so many string/categorical variables.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

Nope!