### PR TITLE
Improve labeled dataset cleanup logic

### DIFF
--- a/tests/analysis/pdp/test_dataops.py
+++ b/tests/analysis/pdp/test_dataops.py
@@ -210,8 +210,8 @@ def test_standardize_course_dataset(df, exp):
                         pd.NA,
                         pd.NA,
                     ],
-                    "frac_credits_earned_year_1": [np.nan, 0.5, 0.75, 0.9],
-                    "frac_credits_earned_year_2": [np.nan, np.nan, 0.8, 0.85],
+                    "frac_credits_earned_year_1": [1.0, 0.5, 0.75, 0.9],
+                    "frac_credits_earned_year_2": [np.nan, 0.75, 0.8, 0.85],
                     "num_courses_diff_term_2_to_term_3": [np.nan, 1.0, -1.0, 0.0],
                     "num_courses_diff_term_3_to_term_4": [np.nan, np.nan, 0.0, 1.0],
                 }


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

refactors how year/term values get masked in cleanup function, such that the input dataframe's dtypes are preserved; this function used to mangle dtypes, which was a pain point in the modeling dataset workflow

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

Just taking the time to smooth out some rough edges.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- Are the new functions logical equivalents of the old ones? They _should_ be, but `pandas` is tricksy 🤷‍♂️ 