### PR TITLE
[pdp] Map feature columns to human-friendly names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "seaborn~=0.13",
     "statsmodels~=0.14",
     "shap~=0.46.0",
+    "tomli~=2.0; python_version<'3.11'",
 ]
 
 [project.urls]

--- a/src/student_success_tool/assets/pdp/features_table.toml
+++ b/src/student_success_tool/assets/pdp/features_table.toml
@@ -62,43 +62,35 @@ num_courses_grade_above_section_avg = { name = "number of courses this term with
 cohort_term = { name = "student's cohort (enrollment) term" }
 enrollment_type = { name = "student's enrollment type " }
 enrollment_intensity_first_term = { name = "student's first-term enrollment intensity" }
-math_placement = { name = "TODO" }
-english_placement = { name = "TODO" }
-dual_and_summer_enrollment = { name = "TODO" }
-race = { name = "TODO" }
-ethnicity = { name = "TODO" }
-gender = { name = "TODO" }
-first_gen = { name = "TODO" }
-pell_status_first_year = { name = "TODO" }
-credential_type_sought_year_1 = { name = "TODO" }
-program_of_study_term_1 = { name = "TODO" }
-gpa_group_term_1 = { name = "TODO" }
-gpa_group_year_1 = { name = "TODO" }
-number_of_credits_attempted_year_1 = { name = "TODO" }
-number_of_credits_earned_year_1 = { name = "TODO" }
-number_of_credits_attempted_year_2 = { name = "TODO" }
-number_of_credits_earned_year_2 = { name = "TODO" }
-number_of_credits_attempted_year_3 = { name = "TODO" }
-number_of_credits_earned_year_3 = { name = "TODO" }
-number_of_credits_attempted_year_4 = { name = "TODO" }
-number_of_credits_earned_year_4 = { name = "TODO" }
-reading_placement = { name = "TODO" }
-special_program = { name = "TODO" }
-foreign_language_completion = { name = "TODO" }
-first_year_to_bachelors_at_cohort_inst = { name = "TODO" }
-first_year_to_associates_or_certificate_at_cohort_inst = { name = "TODO" }
-first_year_to_bachelor_at_other_inst = { name = "TODO" }
-first_year_to_associates_or_certificate_at_other_inst = { name = "TODO" }
-program_of_study_year_1 = { name = "TODO" }
-student_program_of_study_area_term_1 = { name = "TODO" }
-student_program_of_study_area_year_1 = { name = "TODO" }
-student_program_of_study_changed_term_1_to_year_1 = { name = "TODO" }
-student_program_of_study_area_changed_term_1_to_year_1 = { name = "TODO" }
-diff_gpa_term_1_to_year_1 = { name = "TODO" }
-frac_credits_earned_year_1 = { name = "TODO" }
-frac_credits_earned_year_2 = { name = "TODO" }
-frac_credits_earned_year_3 = { name = "TODO" }
-frac_credits_earned_year_4 = { name = "TODO" }
+math_placement = { name = "student's math placement upon enrollment" }
+english_placement = { name = "student's english placement upon enrollment" }
+reading_placement = { name = "student's reading placement upon enrollment" }
+dual_and_summer_enrollment = { name = "student's past dual and/or summer enrollment status" }
+pell_status_first_year = { name = "student's first-year Pell status" }
+credential_type_sought_year_1 = { name = "student's first-year credential type sought" }
+program_of_study_term_1 = { name = "student's first-term program of study" }
+program_of_study_year_1 = { name = "student's first-year program of study" }
+gpa_group_term_1 = { name = "student's GPA at end of first term" }
+gpa_group_year_1 = { name = "student's GPA at end of first year" }
+number_of_credits_attempted_year_1 = { name = "total number of credits attempted in year 1" }
+number_of_credits_earned_year_1 = { name = "total number of credits earned in year 1" }
+number_of_credits_attempted_year_2 = { name = "total number of credits attempted in year 2" }
+number_of_credits_earned_year_2 = { name = "total number of credits earned in year 2" }
+number_of_credits_attempted_year_3 = { name = "total number of credits attempted in year 3" }
+number_of_credits_earned_year_3 = { name = "total number of credits earned in year 3" }
+number_of_credits_attempted_year_4 = { name = "total number of credits attempted in year 4" }
+number_of_credits_earned_year_4 = { name = "total number of credits earned in year 4" }
+special_program = { name = "student is participating in a special program" }
+foreign_language_completion = { name = "term/year in which student completed foreign language requirement" }
+student_program_of_study_area_term_1 = { name = "student's first-term program of study area" }
+student_program_of_study_area_year_1 = { name = "student's first-year program of study area" }
+student_program_of_study_changed_term_1_to_year_1 = { name = "student's program of study changed from term 1 to year 1" }
+student_program_of_study_area_changed_term_1_to_year_1 = { name = "student's program of study area changed from term 1 to year 1" }
+diff_gpa_term_1_to_year_1 = { name = "change in student's GPA from term 1 to year 1" }
+frac_credits_earned_year_1 = { name = "fraction of credits earned in year 1" }
+frac_credits_earned_year_2 = { name = "fraction of credits earned in year 2" }
+frac_credits_earned_year_3 = { name = "fraction of credits earned in year 3" }
+frac_credits_earned_year_4 = { name = "fraction of credits earned in year 4" }
 year_of_enrollment_at_cohort_inst = { name = "TODO" }
 term_is_pre_cohort = { name = "TODO" }
 term_is_while_student_enrolled_at_other_inst = { name = "TODO" }

--- a/src/student_success_tool/assets/pdp/features_table.toml
+++ b/src/student_success_tool/assets/pdp/features_table.toml
@@ -15,7 +15,7 @@ course_grade_numeric_std = { name = "std. dev. in numeric course grades this ter
 section_num_students_enrolled_mean = { name = "avg. number of students enrolled per section this term" }
 section_num_students_enrolled_std = { name = "std. dev. in number of students enrolled per section this term" }
 num_courses_core_course_Y = { name = "number of core courses taken this term" }
-num_courses_enrolled_at_other_institution_s_Y = { name = "number of courses taken this term while enrolled at other institution" }
+num_courses_enrolled_at_other_institution_s_Y = { name = "number of courses taken this term while enrolled at another institution" }
 "num_courses_course_subject_area_*" = { name = "TODO: number of courses taken in subject area this term" }
 "num_courses_course_id_*" = { name = "TODO: number of times this course taken this term" }
 num_courses_course_type_CU = { name = "number of college-level, undergraduate courses taken this term" }
@@ -44,14 +44,14 @@ num_courses_course_instructor_rank_4 = { name = "number of courses taken this te
 num_courses_course_instructor_rank_5 = { name = "number of courses taken this term with an associate professor (rank 5)" }
 num_courses_course_instructor_rank_6 = { name = "number of courses taken this term with a professor (rank 6)" }
 num_courses_course_instructor_rank_7 = { name = "number of courses taken this term with an 'other' instructor (rank 7)" }
-num_courses_course_level_1 = { name = "number of level-1 courses taken this term" }
-num_courses_course_level_2 = { name = "number of level-2 courses taken this term" }
-num_courses_course_level_3 = { name = "number of level-3 courses taken this term" }
-num_courses_course_level_4 = { name = "number of level-4 courses taken this term" }
-num_courses_course_level_5 = { name = "number of level-5 courses taken this term" }
-num_courses_course_level_6 = { name = "number of level-6 courses taken this term" }
-num_courses_course_level_7 = { name = "number of level-7 courses taken this term" }
-num_courses_course_level_8 = { name = "number of level-8 courses taken this term" }
+num_courses_course_level_1 = { name = "number of 100-level courses taken this term" }
+num_courses_course_level_2 = { name = "number of 200-level courses taken this term" }
+num_courses_course_level_3 = { name = "number of 300-level courses taken this term" }
+num_courses_course_level_4 = { name = "number of 400-level courses taken this term" }
+num_courses_course_level_5 = { name = "number of 500-level courses taken this term" }
+num_courses_course_level_6 = { name = "number of 600-level courses taken this term" }
+num_courses_course_level_7 = { name = "number of 700-level courses taken this term" }
+num_courses_course_level_8 = { name = "number of 800-level courses taken this term" }
 num_courses_course_grade_a = { name = "number of A grades earned this term" }
 num_courses_course_grade_b = { name = "number of B grades earned this term" }
 num_courses_course_grade_c = { name = "number of C grades earned this term" }
@@ -91,139 +91,137 @@ frac_credits_earned_year_1 = { name = "fraction of credits earned in year 1" }
 frac_credits_earned_year_2 = { name = "fraction of credits earned in year 2" }
 frac_credits_earned_year_3 = { name = "fraction of credits earned in year 3" }
 frac_credits_earned_year_4 = { name = "fraction of credits earned in year 4" }
-year_of_enrollment_at_cohort_inst = { name = "TODO" }
-term_is_pre_cohort = { name = "TODO" }
-term_is_while_student_enrolled_at_other_inst = { name = "TODO" }
-frac_credits_earned = { name = "TODO" }
-student_term_enrollment_intensity = { name = "TODO" }
-num_courses_in_program_of_study_area_term_1 = { name = "TODO" }
-num_courses_in_program_of_study_area_year_1 = { name = "TODO" }
-frac_courses_passed = { name = "TODO" }
-frac_courses_completed = { name = "TODO" }
-frac_courses_core_course_Y = { name = "TODO" }
-frac_courses_enrolled_at_other_institution_s_Y = { name = "TODO" }
-frac_courses_course_subject_area_51 = { name = "TODO" }
-frac_courses_course_id_ENGLB101 = { name = "TODO" }
-frac_courses_course_id_ENGLB102 = { name = "TODO" }
-frac_courses_course_type_CU = { name = "TODO" }
-frac_courses_course_type_CG = { name = "TODO" }
-frac_courses_course_type_CC = { name = "TODO" }
-frac_courses_course_type_CD = { name = "TODO" }
-frac_courses_course_type_EL = { name = "TODO" }
-frac_courses_course_type_AB = { name = "TODO" }
-frac_courses_course_type_GE = { name = "TODO" }
-frac_courses_course_type_NC = { name = "TODO" }
-frac_courses_course_type_O = { name = "TODO" }
-frac_courses_delivery_method_F = { name = "TODO" }
-frac_courses_delivery_method_O = { name = "TODO" }
-frac_courses_delivery_method_H = { name = "TODO" }
-frac_courses_math_or_english_gateway_M = { name = "TODO" }
-frac_courses_math_or_english_gateway_E = { name = "TODO" }
-frac_courses_math_or_english_gateway_NA = { name = "TODO" }
-frac_courses_co_requisite_course_Y = { name = "TODO" }
-frac_courses_co_requisite_course_N = { name = "TODO" }
-frac_courses_course_instructor_employment_status_PT = { name = "TODO" }
-frac_courses_course_instructor_employment_status_FT = { name = "TODO" }
-frac_courses_course_instructor_rank_1 = { name = "TODO" }
-frac_courses_course_instructor_rank_2 = { name = "TODO" }
-frac_courses_course_instructor_rank_3 = { name = "TODO" }
-frac_courses_course_instructor_rank_4 = { name = "TODO" }
-frac_courses_course_instructor_rank_5 = { name = "TODO" }
-frac_courses_course_instructor_rank_6 = { name = "TODO" }
-frac_courses_course_instructor_rank_7 = { name = "TODO" }
-frac_courses_course_level_1 = { name = "TODO" }
-frac_courses_course_level_2 = { name = "TODO" }
-frac_courses_course_level_3 = { name = "TODO" }
-frac_courses_course_level_4 = { name = "TODO" }
-frac_courses_course_level_5 = { name = "TODO" }
-frac_courses_course_level_6 = { name = "TODO" }
-frac_courses_course_level_7 = { name = "TODO" }
-frac_courses_course_level_8 = { name = "TODO" }
-frac_courses_course_grade_A = { name = "TODO" }
-frac_courses_course_grade_B = { name = "TODO" }
-frac_courses_course_grade_C = { name = "TODO" }
-frac_courses_course_grade_D = { name = "TODO" }
-frac_courses_course_grade_F = { name = "TODO" }
-frac_courses_grade_is_failing_or_withdrawal = { name = "TODO" }
-frac_courses_grade_above_section_avg = { name = "TODO" }
-frac_sections_students_passed = { name = "TODO" }
-frac_sections_students_completed = { name = "TODO" }
-student_pass_rate_above_sections_avg = { name = "TODO" }
-student_completion_rate_above_sections_avg = { name = "TODO" }
-cumnum_unique_course_ids = { name = "TODO" }
-cumnum_unique_course_subjects = { name = "TODO" }
-cumnum_unique_course_subject_areas = { name = "TODO" }
-cumnum_repeated_course_ids = { name = "TODO" }
-cumnum_repeated_course_subjects = { name = "TODO" }
-cumnum_repeated_course_subject_areas = { name = "TODO" }
-cumnum_terms_enrolled = { name = "TODO" }
-term_in_peak_covid_cumsum = { name = "TODO" }
-cumnum_fall_spring_terms_enrolled = { name = "TODO" }
-term_is_while_student_enrolled_at_other_inst_cumsum = { name = "TODO" }
-term_is_pre_cohort_cumsum = { name = "TODO" }
-course_level_mean_cummean = { name = "TODO" }
-course_level_mean_cummin = { name = "TODO" }
-course_level_mean_cumstd = { name = "TODO" }
-course_grade_numeric_mean_cummean = { name = "TODO" }
-course_grade_numeric_mean_cummin = { name = "TODO" }
-course_grade_numeric_mean_cumstd = { name = "TODO" }
-num_courses_cumsum = { name = "TODO" }
-num_courses_cummean = { name = "TODO" }
-num_courses_cummin = { name = "TODO" }
-num_credits_attempted_cumsum = { name = "TODO" }
-num_credits_attempted_cummean = { name = "TODO" }
-num_credits_attempted_cummin = { name = "TODO" }
-num_credits_earned_cumsum = { name = "TODO" }
-num_credits_earned_cummean = { name = "TODO" }
-num_credits_earned_cummin = { name = "TODO" }
+year_of_enrollment_at_cohort_inst = { name = "year of enrollment at cohort institution" }
+term_is_pre_cohort = { name = "term occurred before student's cohort (enrollment) term" }
+term_is_while_student_enrolled_at_other_inst = { name = "term occurred while student is enrolled at another institution" }
+frac_credits_earned = { name = "fraction of credits earned this term" }
+student_term_enrollment_intensity = { name = "student's enrollment intensity this term" }
+num_courses_in_program_of_study_area_term_1 = { name = "number of courses taken this term in student's first-term program of study area" }
+num_courses_in_program_of_study_area_year_1 = { name = "number of courses taken this term in student's first-year program of study area" }
+frac_courses_passed = { name = "fraction of courses passed this term" }
+frac_courses_completed = { name = "fraction of courses completed this term" }
+frac_courses_core_course_Y = { name = "fraction of core courses taken this term" }
+frac_courses_enrolled_at_other_institution_s_Y = { name = "fraction of courses taken this term while student enrolled at another institution" }
+"frac_courses_course_subject_area_*" = { name = "TODO" }
+"frac_courses_course_id_*" = { name = "TODO" }
+frac_courses_course_type_CU = { name = "fraction of college-level, undergraduate courses taken this term" }
+frac_courses_course_type_CG = { name = "fraction of college-level, graduate courses taken this term" }
+frac_courses_course_type_CC = { name = "fraction of college developmental, remedial, or preparatory courses taken this term" }
+frac_courses_course_type_CD = { name = "fraction of college developmental, remedial, or preparatory courses taken this term" }
+frac_courses_course_type_EL = { name = "fraction of ESL courses taken this term" }
+frac_courses_course_type_AB = { name = "fraction of adult basic education courses taken this term" }
+frac_courses_course_type_GE = { name = "fraction of adult secondary education / GED courses taken this term" }
+frac_courses_course_type_NC = { name = "fraction of non-credit vocational courses taken this term" }
+frac_courses_course_type_O = { name = "fraction of 'other' courses taken this term" }
+frac_courses_delivery_method_F = { name = "fraction of face-to-face courses taken this term" }
+frac_courses_delivery_method_O = { name = "fraction of online courses taken this term" }
+frac_courses_delivery_method_H = { name = "fraction of hybrid (face-to-face / online) courses taken this term" }
+frac_courses_math_or_english_gateway_M = { name = "fraction of math gateway courses taken this term" }
+frac_courses_math_or_english_gateway_E = { name = "fraction of english gateway courses taken this term" }
+frac_courses_math_or_english_gateway_NA = { name = "fraction of non-gateway courses taken this term" }
+frac_courses_co_requisite_course_Y = { name = "fraction of co-requisite courses taken this term" }
+frac_courses_co_requisite_course_N = { name = "fraction of non-co-requsite courses taken this term" }
+frac_courses_course_instructor_employment_status_PT = { name = "fraction of courses taken this term with a part-time instructor" }
+frac_courses_course_instructor_employment_status_FT = { name = "fraction of courses taken this term with a full-time instructor" }
+frac_courses_course_instructor_rank_1 = { name = "fraction of courses taken this term with an instructor (rank 1)" }
+frac_courses_course_instructor_rank_2 = { name = "fraction of courses taken this term with a lecturer (rank 2)" }
+frac_courses_course_instructor_rank_3 = { name = "fraction of courses taken this term with a senior lecturer (rank 3)" }
+frac_courses_course_instructor_rank_4 = { name = "fraction of courses taken this term with an assistant professor (rank 4)" }
+frac_courses_course_instructor_rank_5 = { name = "fraction of courses taken this term with an associate professor (rank 5)" }
+frac_courses_course_instructor_rank_6 = { name = "fraction of courses taken this term with a professor (rank 6)" }
+frac_courses_course_instructor_rank_7 = { name = "fraction of courses taken this term with an 'other' instructor (rank 7)" }
+frac_courses_course_level_1 = { name = "fraction of 100-level courses taken this term" }
+frac_courses_course_level_2 = { name = "fraction of 200-level courses taken this term" }
+frac_courses_course_level_3 = { name = "fraction of 300-level courses taken this term" }
+frac_courses_course_level_4 = { name = "fraction of 400-level courses taken this term" }
+frac_courses_course_level_5 = { name = "fraction of 500-level courses taken this term" }
+frac_courses_course_level_6 = { name = "fraction of 600-level courses taken this term" }
+frac_courses_course_level_7 = { name = "fraction of 700-level courses taken this term" }
+frac_courses_course_level_8 = { name = "fraction of 800-level courses taken this term" }
+frac_courses_course_grade_a = { name = "fraction of A grades earned this term" }
+frac_courses_course_grade_b = { name = "fraction of B grades earned this term" }
+frac_courses_course_grade_c = { name = "fraction of C grades earned this term" }
+frac_courses_course_grade_d = { name = "fraction of D grades earned this term" }
+frac_courses_course_grade_f = { name = "fraction of F grades earned this term" }
+frac_courses_grade_is_failing_or_withdrawal = { name = "fraction of courses failed or withdrawn this term" }
+frac_courses_grade_above_section_avg = { name = "fraction of courses this term with grades above the sections' avg. grades" }
+frac_sections_students_passed = { name = "fraction of section's students that passed the course" }
+frac_sections_students_completed = { name = "fraction of section's students that completed the course" }
+student_pass_rate_above_sections_avg = { name = "student's pass rate this term is above sections' avg. pass rate" }
+student_completion_rate_above_sections_avg = { name = "student's completion rate this term is above sections' avg. completion rate" }
+cumnum_unique_course_ids = { name = "number of unique courses taken so far" }
+cumnum_unique_course_subjects = { name = "number of unique course subjects taken so far" }
+cumnum_unique_course_subject_areas = { name = "number of unique course subject areas taken so far" }
+cumnum_repeated_course_ids = { name = "number of courses repeated so far" }
+cumnum_repeated_course_subjects = { name = "number of course subjects repeated so far" }
+cumnum_repeated_course_subject_areas = { name = "number of course subject areas repeated so far" }
+cumnum_terms_enrolled = { name = "number of terms enrolled so far" }
+cumnum_fall_spring_terms_enrolled = { name = "number of fall or spring terms enrolled so far" }
+term_in_peak_covid_cumsum = { name = "number of terms so far that occurred in 'peak' COVID" }
+term_is_while_student_enrolled_at_other_inst_cumsum = { name = "number of terms so far that occurred while student was enrolled at another institution" }
+term_is_pre_cohort_cumsum = { name = "number of terms so far that occurred before student's cohort (enrollment) term" }
+course_level_mean_cummean = { name = "avg. course level so far" }
+course_level_mean_cummin = { name = "min. course level so far" }
+course_level_mean_cumstd = { name = "std. dev. in course levels so far" }
+course_grade_numeric_mean_cummean = { name = "avg. numeric course grade so far" }
+course_grade_numeric_mean_cummin = { name = "min. numeric course grade so far" }
+course_grade_numeric_mean_cumstd = { name = "std. dev. in numeric course grades so far" }
+num_courses_cumsum = { name = "total number of courses taken so far" }
+num_courses_cummean = { name = "avg. number of courses taken per term so far" }
+num_courses_cummin = { name = "min. number of courses taken per term so far" }
+num_credits_attempted_cumsum = { name = "total number of credits attempted so far" }
+num_credits_attempted_cummean = { name = "avg. number of credits attempted per term so far" }
+num_credits_attempted_cummin = { name = "min. number of credits attempted per term so far" }
+num_credits_earned_cumsum = { name = "total number of credits earned so far" }
+num_credits_earned_cummean = { name = "avg. number of credits earned per term so far" }
+num_credits_earned_cummin = { name = "min. number of credits earned per term so far" }
 student_pass_rate_above_sections_avg_cumsum = { name = "TODO" }
 student_completion_rate_above_sections_avg_cumsum = { name = "TODO" }
-num_courses_passed_cumfrac = { name = "TODO" }
-num_courses_completed_cumfrac = { name = "TODO" }
-num_courses_core_course_Y_cumfrac = { name = "TODO" }
+num_courses_passed_cumfrac = { name = "fraction of courses passed so far" }
+num_courses_completed_cumfrac = { name = "fraction of courses completed so far" }
+num_courses_core_course_Y_cumfrac = { name = "fraction of core courses taken so far" }
 num_courses_enrolled_at_other_institution_s_Y_cumfrac = { name = "TODO" }
-num_courses_course_subject_area_51_cumfrac = { name = "TODO" }
-num_courses_course_id_ENGLB101_cumfrac = { name = "TODO" }
-num_courses_course_id_ENGLB102_cumfrac = { name = "TODO" }
-num_courses_course_type_CU_cumfrac = { name = "TODO" }
-num_courses_course_type_CG_cumfrac = { name = "TODO" }
-num_courses_course_type_CC_cumfrac = { name = "TODO" }
-num_courses_course_type_CD_cumfrac = { name = "TODO" }
-num_courses_course_type_EL_cumfrac = { name = "TODO" }
-num_courses_course_type_AB_cumfrac = { name = "TODO" }
-num_courses_course_type_GE_cumfrac = { name = "TODO" }
-num_courses_course_type_NC_cumfrac = { name = "TODO" }
-num_courses_course_type_O_cumfrac = { name = "TODO" }
-num_courses_delivery_method_F_cumfrac = { name = "TODO" }
-num_courses_delivery_method_O_cumfrac = { name = "TODO" }
-num_courses_delivery_method_H_cumfrac = { name = "TODO" }
-num_courses_math_or_english_gateway_M_cumfrac = { name = "TODO" }
-num_courses_math_or_english_gateway_E_cumfrac = { name = "TODO" }
-num_courses_math_or_english_gateway_NA_cumfrac = { name = "TODO" }
-num_courses_co_requisite_course_Y_cumfrac = { name = "TODO" }
-num_courses_co_requisite_course_N_cumfrac = { name = "TODO" }
-num_courses_course_instructor_employment_status_PT_cumfrac = { name = "TODO" }
-num_courses_course_instructor_employment_status_FT_cumfrac = { name = "TODO" }
-num_courses_course_instructor_rank_1_cumfrac = { name = "TODO" }
-num_courses_course_instructor_rank_2_cumfrac = { name = "TODO" }
-num_courses_course_instructor_rank_3_cumfrac = { name = "TODO" }
-num_courses_course_instructor_rank_4_cumfrac = { name = "TODO" }
-num_courses_course_instructor_rank_5_cumfrac = { name = "TODO" }
-num_courses_course_instructor_rank_6_cumfrac = { name = "TODO" }
-num_courses_course_instructor_rank_7_cumfrac = { name = "TODO" }
-num_courses_course_level_1_cumfrac = { name = "TODO" }
-num_courses_course_level_2_cumfrac = { name = "TODO" }
-num_courses_course_level_3_cumfrac = { name = "TODO" }
-num_courses_course_level_4_cumfrac = { name = "TODO" }
-num_courses_course_level_5_cumfrac = { name = "TODO" }
-num_courses_course_level_6_cumfrac = { name = "TODO" }
-num_courses_course_level_7_cumfrac = { name = "TODO" }
-num_courses_course_level_8_cumfrac = { name = "TODO" }
-num_courses_course_grade_A_cumfrac = { name = "TODO" }
-num_courses_course_grade_B_cumfrac = { name = "TODO" }
-num_courses_course_grade_C_cumfrac = { name = "TODO" }
-num_courses_course_grade_D_cumfrac = { name = "TODO" }
-num_courses_course_grade_F_cumfrac = { name = "TODO" }
+"num_courses_course_subject_area_*_cumfrac" = { name = "TODO" }
+"num_courses_course_id_*_cumfrac" = { name = "TODO" }
+num_courses_course_type_CU_cumfrac = { name = "fraction of college-level, undergraduate courses taken so far" }
+num_courses_course_type_CG_cumfrac = { name = "fraction of college-level, graduate courses taken so far" }
+num_courses_course_type_CC_cumfrac = { name = "fraction of college developmental, remedial, or preparatory courses taken so far" }
+num_courses_course_type_CD_cumfrac = { name = "fraction of college developmental, remedial, or preparatory courses taken so far" }
+num_courses_course_type_EL_cumfrac = { name = "fraction of ESL courses taken so far" }
+num_courses_course_type_AB_cumfrac = { name = "fraction of adult basic education courses taken so far" }
+num_courses_course_type_GE_cumfrac = { name = "fraction of adult secondary education / GED courses taken so far" }
+num_courses_course_type_NC_cumfrac = { name = "fraction of non-credit vocational courses taken so far" }
+num_courses_course_type_O_cumfrac = { name = "fraction of 'other' courses taken so far" }
+num_courses_delivery_method_F_cumfrac = { name = "fraction of face-to-face courses taken so far" }
+num_courses_delivery_method_O_cumfrac = { name = "fraction of online courses taken so far" }
+num_courses_delivery_method_H_cumfrac = { name = "fraction of hybrid (face-to-face / online) courses taken so far" }
+num_courses_math_or_english_gateway_M_cumfrac = { name = "fraction of math gateway courses taken so far" }
+num_courses_math_or_english_gateway_E_cumfrac = { name = "fraction of english gateway courses taken so far" }
+num_courses_math_or_english_gateway_NA_cumfrac = { name = "fraction of non-gateway courses taken so far" }
+num_courses_co_requisite_course_Y_cumfrac = { name = "fraction of co-requisite courses taken so far" }
+num_courses_co_requisite_course_N_cumfrac = { name = "fraction of non-co-requsite courses taken so far" }
+num_courses_course_instructor_employment_status_PT_cumfrac = { name = "fraction of courses taken so far with a part-time instructor" }
+num_courses_course_instructor_employment_status_FT_cumfrac = { name = "fraction of courses taken so far with a full-time instructor" }
+num_courses_course_instructor_rank_1_cumfrac = { name = "fraction of courses taken so far with an instructor (rank 1)" }
+num_courses_course_instructor_rank_2_cumfrac = { name = "fraction of courses taken so far with a lecturer (rank 2)" }
+num_courses_course_instructor_rank_3_cumfrac = { name = "fraction of courses taken so far with a senior lecturer (rank 3)" }
+num_courses_course_instructor_rank_4_cumfrac = { name = "fraction of courses taken so far with an assistant professor (rank 4)" }
+num_courses_course_instructor_rank_5_cumfrac = { name = "fraction of courses taken so far with an associate professor (rank 5)" }
+num_courses_course_instructor_rank_6_cumfrac = { name = "fraction of courses taken so far with a professor (rank 6)" }
+num_courses_course_instructor_rank_7_cumfrac = { name = "fraction of courses taken so far with an 'other' instructor (rank 7)" }
+num_courses_course_level_1_cumfrac = { name = "fraction of 100-level courses taken so far" }
+num_courses_course_level_2_cumfrac = { name = "fraction of 200-level courses taken so far" }
+num_courses_course_level_3_cumfrac = { name = "fraction of 300-level courses taken so far" }
+num_courses_course_level_4_cumfrac = { name = "fraction of 400-level courses taken so far" }
+num_courses_course_level_5_cumfrac = { name = "fraction of 500-level courses taken so far" }
+num_courses_course_level_6_cumfrac = { name = "fraction of 600-level courses taken so far" }
+num_courses_course_level_7_cumfrac = { name = "fraction of 700-level courses taken so far" }
+num_courses_course_level_8_cumfrac = { name = "fraction of 800-level courses taken so far" }
+num_courses_course_grade_a_cumfrac = { name = "fraction of A grades earned so far" }
+num_courses_course_grade_b_cumfrac = { name = "fraction of B grades earned so far" }
+num_courses_course_grade_c_cumfrac = { name = "fraction of C grades earned so far" }
+num_courses_course_grade_d_cumfrac = { name = "fraction of D grades earned so far" }
+num_courses_course_grade_f_cumfrac = { name = "fraction of F grades earned so far" }
 num_courses_grade_is_failing_or_withdrawal_cumfrac = { name = "TODO" }
 num_courses_grade_above_section_avg_cumfrac = { name = "TODO" }
 num_courses_in_program_of_study_area_term_1_cumfrac = { name = "TODO" }

--- a/src/student_success_tool/assets/pdp/features_table.toml
+++ b/src/student_success_tool/assets/pdp/features_table.toml
@@ -14,29 +14,29 @@ course_grade_numeric_mean = { name = "avg. numeric course grade this term" }
 course_grade_numeric_std = { name = "std. dev. in numeric course grades this term" }
 section_num_students_enrolled_mean = { name = "avg. number of students enrolled per section this term" }
 section_num_students_enrolled_std = { name = "std. dev. in number of students enrolled per section this term" }
-num_courses_core_course_Y = { name = "number of core courses taken this term" }
-num_courses_enrolled_at_other_institution_s_Y = { name = "number of courses taken this term while enrolled at another institution" }
+num_courses_core_course_y = { name = "number of core courses taken this term" }
+num_courses_enrolled_at_other_institution_s_y = { name = "number of courses taken this term while enrolled at another institution" }
 "num_courses_course_subject_area_*" = { name = "TODO: number of courses taken in subject area this term" }
 "num_courses_course_id_*" = { name = "TODO: number of times this course taken this term" }
-num_courses_course_type_CU = { name = "number of college-level, undergraduate courses taken this term" }
-num_courses_course_type_CG = { name = "number of college-level, graduate courses taken this term" }
-num_courses_course_type_CC = { name = "number of college developmental, remedial, or preparatory courses taken this term" }
-num_courses_course_type_CD = { name = "number of college developmental, remedial, or preparatory courses taken this term" }
-num_courses_course_type_EL = { name = "number of ESL courses taken this term" }
-num_courses_course_type_AB = { name = "number of adult basic education courses taken this term" }
-num_courses_course_type_GE = { name = "number of adult secondary education / GED courses taken this term" }
-num_courses_course_type_NC = { name = "number of non-credit vocational courses taken this term" }
-num_courses_course_type_O = { name = "number of 'other' courses taken this term" }
-num_courses_delivery_method_F = { name = "number of face-to-face courses taken this term" }
-num_courses_delivery_method_O = { name = "number of online courses taken this term" }
-num_courses_delivery_method_H = { name = "number of hybrid (face-to-face / online) courses taken this term" }
-num_courses_math_or_english_gateway_M = { name = "number of math gateway courses taken this term" }
-num_courses_math_or_english_gateway_E = { name = "number of english gateway courses taken this term" }
-num_courses_math_or_english_gateway_NA = { name = "number of non-gateway courses taken this term" }
-num_courses_co_requisite_course_Y = { name = "number of co-requisite courses taken this term" }
-num_courses_co_requisite_course_N = { name = "number of non-co-requsite courses taken this term" }
-num_courses_course_instructor_employment_status_PT = { name = "number of courses taken this term with a part-time instructor" }
-num_courses_course_instructor_employment_status_FT = { name = "number of courses taken this term with a full-time instructor" }
+num_courses_course_type_cu = { name = "number of college-level, undergraduate courses taken this term" }
+num_courses_course_type_cg = { name = "number of college-level, graduate courses taken this term" }
+num_courses_course_type_cc = { name = "number of college developmental, remedial, or preparatory courses taken this term" }
+num_courses_course_type_cd = { name = "number of college developmental, remedial, or preparatory courses taken this term" }
+num_courses_course_type_el = { name = "number of ESL courses taken this term" }
+num_courses_course_type_ab = { name = "number of adult basic education courses taken this term" }
+num_courses_course_type_ge = { name = "number of adult secondary education / GED courses taken this term" }
+num_courses_course_type_nc = { name = "number of non-credit vocational courses taken this term" }
+num_courses_course_type_o = { name = "number of 'other' courses taken this term" }
+num_courses_delivery_method_f = { name = "number of face-to-face courses taken this term" }
+num_courses_delivery_method_o = { name = "number of online courses taken this term" }
+num_courses_delivery_method_h = { name = "number of hybrid (face-to-face / online) courses taken this term" }
+num_courses_math_or_english_gateway_m = { name = "number of math gateway courses taken this term" }
+num_courses_math_or_english_gateway_e = { name = "number of english gateway courses taken this term" }
+num_courses_math_or_english_gateway_na = { name = "number of non-gateway courses taken this term" }
+num_courses_co_requisite_course_y = { name = "number of co-requisite courses taken this term" }
+num_courses_co_requisite_course_n = { name = "number of non-co-requsite courses taken this term" }
+num_courses_course_instructor_employment_status_pt = { name = "number of courses taken this term with a part-time instructor" }
+num_courses_course_instructor_employment_status_ft = { name = "number of courses taken this term with a full-time instructor" }
 num_courses_course_instructor_rank_1 = { name = "number of courses taken this term with an instructor (rank 1)" }
 num_courses_course_instructor_rank_2 = { name = "number of courses taken this term with a lecturer (rank 2)" }
 num_courses_course_instructor_rank_3 = { name = "number of courses taken this term with a senior lecturer (rank 3)" }
@@ -100,29 +100,29 @@ num_courses_in_program_of_study_area_term_1 = { name = "number of courses taken 
 num_courses_in_program_of_study_area_year_1 = { name = "number of courses taken this term in student's first-year program of study area" }
 frac_courses_passed = { name = "fraction of courses passed this term" }
 frac_courses_completed = { name = "fraction of courses completed this term" }
-frac_courses_core_course_Y = { name = "fraction of core courses taken this term" }
-frac_courses_enrolled_at_other_institution_s_Y = { name = "fraction of courses taken this term while student enrolled at another institution" }
+frac_courses_core_course_y = { name = "fraction of core courses taken this term" }
+frac_courses_enrolled_at_other_institution_s_y = { name = "fraction of courses taken this term while student enrolled at another institution" }
 "frac_courses_course_subject_area_*" = { name = "TODO" }
 "frac_courses_course_id_*" = { name = "TODO" }
-frac_courses_course_type_CU = { name = "fraction of college-level, undergraduate courses taken this term" }
-frac_courses_course_type_CG = { name = "fraction of college-level, graduate courses taken this term" }
-frac_courses_course_type_CC = { name = "fraction of college developmental, remedial, or preparatory courses taken this term" }
-frac_courses_course_type_CD = { name = "fraction of college developmental, remedial, or preparatory courses taken this term" }
-frac_courses_course_type_EL = { name = "fraction of ESL courses taken this term" }
-frac_courses_course_type_AB = { name = "fraction of adult basic education courses taken this term" }
-frac_courses_course_type_GE = { name = "fraction of adult secondary education / GED courses taken this term" }
-frac_courses_course_type_NC = { name = "fraction of non-credit vocational courses taken this term" }
-frac_courses_course_type_O = { name = "fraction of 'other' courses taken this term" }
-frac_courses_delivery_method_F = { name = "fraction of face-to-face courses taken this term" }
-frac_courses_delivery_method_O = { name = "fraction of online courses taken this term" }
-frac_courses_delivery_method_H = { name = "fraction of hybrid (face-to-face / online) courses taken this term" }
-frac_courses_math_or_english_gateway_M = { name = "fraction of math gateway courses taken this term" }
-frac_courses_math_or_english_gateway_E = { name = "fraction of english gateway courses taken this term" }
-frac_courses_math_or_english_gateway_NA = { name = "fraction of non-gateway courses taken this term" }
-frac_courses_co_requisite_course_Y = { name = "fraction of co-requisite courses taken this term" }
-frac_courses_co_requisite_course_N = { name = "fraction of non-co-requsite courses taken this term" }
-frac_courses_course_instructor_employment_status_PT = { name = "fraction of courses taken this term with a part-time instructor" }
-frac_courses_course_instructor_employment_status_FT = { name = "fraction of courses taken this term with a full-time instructor" }
+frac_courses_course_type_cu = { name = "fraction of college-level, undergraduate courses taken this term" }
+frac_courses_course_type_cg = { name = "fraction of college-level, graduate courses taken this term" }
+frac_courses_course_type_cc = { name = "fraction of college developmental, remedial, or preparatory courses taken this term" }
+frac_courses_course_type_cd = { name = "fraction of college developmental, remedial, or preparatory courses taken this term" }
+frac_courses_course_type_el = { name = "fraction of ESL courses taken this term" }
+frac_courses_course_type_ab = { name = "fraction of adult basic education courses taken this term" }
+frac_courses_course_type_ge = { name = "fraction of adult secondary education / GED courses taken this term" }
+frac_courses_course_type_nc = { name = "fraction of non-credit vocational courses taken this term" }
+frac_courses_course_type_o = { name = "fraction of 'other' courses taken this term" }
+frac_courses_delivery_method_f = { name = "fraction of face-to-face courses taken this term" }
+frac_courses_delivery_method_o = { name = "fraction of online courses taken this term" }
+frac_courses_delivery_method_h = { name = "fraction of hybrid (face-to-face / online) courses taken this term" }
+frac_courses_math_or_english_gateway_m = { name = "fraction of math gateway courses taken this term" }
+frac_courses_math_or_english_gateway_e = { name = "fraction of english gateway courses taken this term" }
+frac_courses_math_or_english_gateway_na = { name = "fraction of non-gateway courses taken this term" }
+frac_courses_co_requisite_course_y = { name = "fraction of co-requisite courses taken this term" }
+frac_courses_co_requisite_course_n = { name = "fraction of non-co-requsite courses taken this term" }
+frac_courses_course_instructor_employment_status_pt = { name = "fraction of courses taken this term with a part-time instructor" }
+frac_courses_course_instructor_employment_status_ft = { name = "fraction of courses taken this term with a full-time instructor" }
 frac_courses_course_instructor_rank_1 = { name = "fraction of courses taken this term with an instructor (rank 1)" }
 frac_courses_course_instructor_rank_2 = { name = "fraction of courses taken this term with a lecturer (rank 2)" }
 frac_courses_course_instructor_rank_3 = { name = "fraction of courses taken this term with a senior lecturer (rank 3)" }
@@ -179,29 +179,29 @@ student_pass_rate_above_sections_avg_cumsum = { name = "TODO" }
 student_completion_rate_above_sections_avg_cumsum = { name = "TODO" }
 num_courses_passed_cumfrac = { name = "fraction of courses passed so far" }
 num_courses_completed_cumfrac = { name = "fraction of courses completed so far" }
-num_courses_core_course_Y_cumfrac = { name = "fraction of core courses taken so far" }
-num_courses_enrolled_at_other_institution_s_Y_cumfrac = { name = "TODO" }
+num_courses_core_course_y_cumfrac = { name = "fraction of core courses taken so far" }
+num_courses_enrolled_at_other_institution_s_y_cumfrac = { name = "TODO" }
 "num_courses_course_subject_area_*_cumfrac" = { name = "TODO" }
 "num_courses_course_id_*_cumfrac" = { name = "TODO" }
-num_courses_course_type_CU_cumfrac = { name = "fraction of college-level, undergraduate courses taken so far" }
-num_courses_course_type_CG_cumfrac = { name = "fraction of college-level, graduate courses taken so far" }
-num_courses_course_type_CC_cumfrac = { name = "fraction of college developmental, remedial, or preparatory courses taken so far" }
-num_courses_course_type_CD_cumfrac = { name = "fraction of college developmental, remedial, or preparatory courses taken so far" }
-num_courses_course_type_EL_cumfrac = { name = "fraction of ESL courses taken so far" }
-num_courses_course_type_AB_cumfrac = { name = "fraction of adult basic education courses taken so far" }
-num_courses_course_type_GE_cumfrac = { name = "fraction of adult secondary education / GED courses taken so far" }
-num_courses_course_type_NC_cumfrac = { name = "fraction of non-credit vocational courses taken so far" }
-num_courses_course_type_O_cumfrac = { name = "fraction of 'other' courses taken so far" }
-num_courses_delivery_method_F_cumfrac = { name = "fraction of face-to-face courses taken so far" }
-num_courses_delivery_method_O_cumfrac = { name = "fraction of online courses taken so far" }
-num_courses_delivery_method_H_cumfrac = { name = "fraction of hybrid (face-to-face / online) courses taken so far" }
-num_courses_math_or_english_gateway_M_cumfrac = { name = "fraction of math gateway courses taken so far" }
-num_courses_math_or_english_gateway_E_cumfrac = { name = "fraction of english gateway courses taken so far" }
-num_courses_math_or_english_gateway_NA_cumfrac = { name = "fraction of non-gateway courses taken so far" }
-num_courses_co_requisite_course_Y_cumfrac = { name = "fraction of co-requisite courses taken so far" }
-num_courses_co_requisite_course_N_cumfrac = { name = "fraction of non-co-requsite courses taken so far" }
-num_courses_course_instructor_employment_status_PT_cumfrac = { name = "fraction of courses taken so far with a part-time instructor" }
-num_courses_course_instructor_employment_status_FT_cumfrac = { name = "fraction of courses taken so far with a full-time instructor" }
+num_courses_course_type_cu_cumfrac = { name = "fraction of college-level, undergraduate courses taken so far" }
+num_courses_course_type_cg_cumfrac = { name = "fraction of college-level, graduate courses taken so far" }
+num_courses_course_type_cc_cumfrac = { name = "fraction of college developmental, remedial, or preparatory courses taken so far" }
+num_courses_course_type_cd_cumfrac = { name = "fraction of college developmental, remedial, or preparatory courses taken so far" }
+num_courses_course_type_el_cumfrac = { name = "fraction of ESL courses taken so far" }
+num_courses_course_type_ab_cumfrac = { name = "fraction of adult basic education courses taken so far" }
+num_courses_course_type_ge_cumfrac = { name = "fraction of adult secondary education / GED courses taken so far" }
+num_courses_course_type_nc_cumfrac = { name = "fraction of non-credit vocational courses taken so far" }
+num_courses_course_type_o_cumfrac = { name = "fraction of 'other' courses taken so far" }
+num_courses_delivery_method_f_cumfrac = { name = "fraction of face-to-face courses taken so far" }
+num_courses_delivery_method_o_cumfrac = { name = "fraction of online courses taken so far" }
+num_courses_delivery_method_h_cumfrac = { name = "fraction of hybrid (face-to-face / online) courses taken so far" }
+num_courses_math_or_english_gateway_m_cumfrac = { name = "fraction of math gateway courses taken so far" }
+num_courses_math_or_english_gateway_e_cumfrac = { name = "fraction of english gateway courses taken so far" }
+num_courses_math_or_english_gateway_na_cumfrac = { name = "fraction of non-gateway courses taken so far" }
+num_courses_co_requisite_course_y_cumfrac = { name = "fraction of co-requisite courses taken so far" }
+num_courses_co_requisite_course_n_cumfrac = { name = "fraction of non-co-requsite courses taken so far" }
+num_courses_course_instructor_employment_status_pt_cumfrac = { name = "fraction of courses taken so far with a part-time instructor" }
+num_courses_course_instructor_employment_status_ft_cumfrac = { name = "fraction of courses taken so far with a full-time instructor" }
 num_courses_course_instructor_rank_1_cumfrac = { name = "fraction of courses taken so far with an instructor (rank 1)" }
 num_courses_course_instructor_rank_2_cumfrac = { name = "fraction of courses taken so far with a lecturer (rank 2)" }
 num_courses_course_instructor_rank_3_cumfrac = { name = "fraction of courses taken so far with a senior lecturer (rank 3)" }
@@ -240,6 +240,3 @@ num_credits_earned_diff_term_3_to_term_4 = { name = "TODO" }
 course_grade_numeric_mean_diff_term_1_to_term_2 = { name = "TODO" }
 course_grade_numeric_mean_diff_term_2_to_term_3 = { name = "TODO" }
 course_grade_numeric_mean_diff_term_3_to_term_4 = { name = "TODO" }
-"num_courses_course_type_CC|CD" = { name = "TODO" }
-"frac_courses_course_type_CC|CD" = { name = "TODO" }
-"num_courses_course_type_CC|CD_cumfrac" = { name = "TODO" }

--- a/src/student_success_tool/assets/pdp/features_table.toml
+++ b/src/student_success_tool/assets/pdp/features_table.toml
@@ -16,8 +16,8 @@ section_num_students_enrolled_mean = { name = "avg. number of students enrolled 
 section_num_students_enrolled_std = { name = "std. dev. in number of students enrolled per section this term" }
 num_courses_core_course_y = { name = "number of core courses taken this term" }
 num_courses_enrolled_at_other_institution_s_y = { name = "number of courses taken this term while enrolled at another institution" }
-"num_courses_course_subject_area_*" = { name = "TODO: number of courses taken in subject area this term" }
-"num_courses_course_id_*" = { name = "TODO: number of times this course taken this term" }
+# "num_courses_course_subject_area_*" = { name = "TODO: number of courses taken in subject area this term" }
+# "num_courses_course_id_*" = { name = "TODO: number of times this course taken this term" }
 num_courses_course_type_cu = { name = "number of college-level, undergraduate courses taken this term" }
 num_courses_course_type_cg = { name = "number of college-level, graduate courses taken this term" }
 num_courses_course_type_cc = { name = "number of college developmental, remedial, or preparatory courses taken this term" }
@@ -102,8 +102,8 @@ frac_courses_passed = { name = "fraction of courses passed this term" }
 frac_courses_completed = { name = "fraction of courses completed this term" }
 frac_courses_core_course_y = { name = "fraction of core courses taken this term" }
 frac_courses_enrolled_at_other_institution_s_y = { name = "fraction of courses taken this term while student enrolled at another institution" }
-"frac_courses_course_subject_area_*" = { name = "TODO" }
-"frac_courses_course_id_*" = { name = "TODO" }
+# "frac_courses_course_subject_area_*" = { name = "TODO: fraction of courses taken in subject area this term" }
+# "frac_courses_course_id_*" = { name = "TODO: fraction of times this course taken this term" }
 frac_courses_course_type_cu = { name = "fraction of college-level, undergraduate courses taken this term" }
 frac_courses_course_type_cg = { name = "fraction of college-level, graduate courses taken this term" }
 frac_courses_course_type_cc = { name = "fraction of college developmental, remedial, or preparatory courses taken this term" }
@@ -175,14 +175,14 @@ num_credits_attempted_cummin = { name = "min. number of credits attempted per te
 num_credits_earned_cumsum = { name = "total number of credits earned so far" }
 num_credits_earned_cummean = { name = "avg. number of credits earned per term so far" }
 num_credits_earned_cummin = { name = "min. number of credits earned per term so far" }
-student_pass_rate_above_sections_avg_cumsum = { name = "TODO" }
-student_completion_rate_above_sections_avg_cumsum = { name = "TODO" }
+student_pass_rate_above_sections_avg_cumsum = { name = "number of terms so far where student's pass rate is above sections' avg. pass rate" }
+student_completion_rate_above_sections_avg_cumsum = { name = "number of terms so far where student's completion rate is above sections' avg. completion rate" }
 num_courses_passed_cumfrac = { name = "fraction of courses passed so far" }
 num_courses_completed_cumfrac = { name = "fraction of courses completed so far" }
 num_courses_core_course_y_cumfrac = { name = "fraction of core courses taken so far" }
-num_courses_enrolled_at_other_institution_s_y_cumfrac = { name = "TODO" }
-"num_courses_course_subject_area_*_cumfrac" = { name = "TODO" }
-"num_courses_course_id_*_cumfrac" = { name = "TODO" }
+num_courses_enrolled_at_other_institution_s_y_cumfrac = { name = "fraction of courses taken so far while student enrolled at another institution" }
+# "num_courses_course_subject_area_*_cumfrac" = { name = "TODO: fraction of courses taken in subject area so far" }
+# "num_courses_course_id_*_cumfrac" = { name = "TODO: fraction of times this course taken so far" }
 num_courses_course_type_cu_cumfrac = { name = "fraction of college-level, undergraduate courses taken so far" }
 num_courses_course_type_cg_cumfrac = { name = "fraction of college-level, graduate courses taken so far" }
 num_courses_course_type_cc_cumfrac = { name = "fraction of college developmental, remedial, or preparatory courses taken so far" }
@@ -222,21 +222,21 @@ num_courses_course_grade_b_cumfrac = { name = "fraction of B grades earned so fa
 num_courses_course_grade_c_cumfrac = { name = "fraction of C grades earned so far" }
 num_courses_course_grade_d_cumfrac = { name = "fraction of D grades earned so far" }
 num_courses_course_grade_f_cumfrac = { name = "fraction of F grades earned so far" }
-num_courses_grade_is_failing_or_withdrawal_cumfrac = { name = "TODO" }
-num_courses_grade_above_section_avg_cumfrac = { name = "TODO" }
-num_courses_in_program_of_study_area_term_1_cumfrac = { name = "TODO" }
-num_courses_in_program_of_study_area_year_1_cumfrac = { name = "TODO" }
-cumfrac_terms_unenrolled = { name = "TODO" }
-cumfrac_fall_spring_terms_unenrolled = { name = "TODO" }
-num_courses_diff_prev_term = { name = "TODO" }
-num_credits_earned_diff_prev_term = { name = "TODO" }
-course_grade_numeric_mean_diff_prev_term = { name = "TODO" }
-num_courses_diff_term_1_to_term_2 = { name = "TODO" }
-num_courses_diff_term_2_to_term_3 = { name = "TODO" }
-num_courses_diff_term_3_to_term_4 = { name = "TODO" }
-num_credits_earned_diff_term_1_to_term_2 = { name = "TODO" }
-num_credits_earned_diff_term_2_to_term_3 = { name = "TODO" }
-num_credits_earned_diff_term_3_to_term_4 = { name = "TODO" }
-course_grade_numeric_mean_diff_term_1_to_term_2 = { name = "TODO" }
-course_grade_numeric_mean_diff_term_2_to_term_3 = { name = "TODO" }
-course_grade_numeric_mean_diff_term_3_to_term_4 = { name = "TODO" }
+num_courses_grade_is_failing_or_withdrawal_cumfrac = { name = "fraction of courses failed or withdrawn so far" }
+num_courses_grade_above_section_avg_cumfrac = { name = "fraction of courses so far with grades above the sections' avg. grades" }
+num_courses_in_program_of_study_area_term_1_cumfrac = { name = "number of courses taken so far in student's first-term program of study area" }
+num_courses_in_program_of_study_area_year_1_cumfrac = { name = "number of courses taken so far in student's first-year program of study area" }
+cumfrac_terms_unenrolled = { name = "fraction of skipped terms so far" }
+cumfrac_fall_spring_terms_unenrolled = { name = "fraction of skipped fall/spring terms so far" }
+num_courses_diff_prev_term = { name = "change in number of courses taken this term compared to previous term" }
+num_credits_earned_diff_prev_term = { name = "change in number of credits earned this term compared to previous term" }
+course_grade_numeric_mean_diff_prev_term = { name = "change in avg. numeric grade this term compared to previous term" }
+num_courses_diff_term_1_to_term_2 = { name = "change in number of courses taken in term 2 compared to term 1" }
+num_courses_diff_term_2_to_term_3 = { name = "change in number of courses taken in term 3 compared to term 2" }
+num_courses_diff_term_3_to_term_4 = { name = "change in number of courses taken in term 4 compared to term 3" }
+num_credits_earned_diff_term_1_to_term_2 = { name = "chang ein number of credits earned in term 2 compared to term 1" }
+num_credits_earned_diff_term_2_to_term_3 = { name = "chang ein number of credits earned in term 3 compared to term 2" }
+num_credits_earned_diff_term_3_to_term_4 = { name = "chang ein number of credits earned in term 4 compared to term 3" }
+course_grade_numeric_mean_diff_term_1_to_term_2 = { name = "change in avg. numeric grade in term 2 compared to term 1" }
+course_grade_numeric_mean_diff_term_2_to_term_3 = { name = "change in avg. numeric grade in term 3 compared to term 2" }
+course_grade_numeric_mean_diff_term_3_to_term_4 = { name = "change in avg. numeric grade in term 4 compared to term 3" }

--- a/src/student_success_tool/assets/pdp/features_table.toml
+++ b/src/student_success_tool/assets/pdp/features_table.toml
@@ -1,0 +1,255 @@
+academic_term = { name = "academic term" }
+term_in_peak_covid = { name = "term occurred in 'peak' COVID" }
+num_courses = { name = "number of courses taken this term" }
+num_courses_passed = { name = "number of courses passed this term" }
+num_courses_completed = { name = "number of courses completed this term" }
+num_credits_attempted = { name = "number of credits attempted this term" }
+num_credits_earned = { name = "number of credits earned this term" }
+course_id_nunique = { name = "number of unique courses taken this term" }
+course_subject_nunique = { name = "number of unique course subjects taken this term" }
+course_subject_area_nunique = { name = "number of unique course subject areas taken this term" }
+course_level_mean = { name = "avg. course level this term" }
+course_level_std = { name = "std. dev. in course levels this term" }
+course_grade_numeric_mean = { name = "avg. numeric course grade this term" }
+course_grade_numeric_std = { name = "std. dev. in numeric course grades this term" }
+section_num_students_enrolled_mean = { name = "avg. number of students enrolled per section this term" }
+section_num_students_enrolled_std = { name = "std. dev. in number of students enrolled per section this term" }
+num_courses_core_course_Y = { name = "number of core courses taken this term" }
+num_courses_enrolled_at_other_institution_s_Y = { name = "number of courses taken this term while enrolled at other institution" }
+"num_courses_course_subject_area_*" = { name = "TODO: number of courses taken in subject area this term" }
+"num_courses_course_id_*" = { name = "TODO: number of times this course taken this term" }
+num_courses_course_type_CU = { name = "number of college-level, undergraduate courses taken this term" }
+num_courses_course_type_CG = { name = "number of college-level, graduate courses taken this term" }
+num_courses_course_type_CC = { name = "number of college developmental, remedial, or preparatory courses taken this term" }
+num_courses_course_type_CD = { name = "number of college developmental, remedial, or preparatory courses taken this term" }
+num_courses_course_type_EL = { name = "number of ESL courses taken this term" }
+num_courses_course_type_AB = { name = "number of adult basic education courses taken this term" }
+num_courses_course_type_GE = { name = "number of adult secondary education / GED courses taken this term" }
+num_courses_course_type_NC = { name = "number of non-credit vocational courses taken this term" }
+num_courses_course_type_O = { name = "number of 'other' courses taken this term" }
+num_courses_delivery_method_F = { name = "number of face-to-face courses taken this term" }
+num_courses_delivery_method_O = { name = "number of online courses taken this term" }
+num_courses_delivery_method_H = { name = "number of hybrid (face-to-face / online) courses taken this term" }
+num_courses_math_or_english_gateway_M = { name = "number of math gateway courses taken this term" }
+num_courses_math_or_english_gateway_E = { name = "number of english gateway courses taken this term" }
+num_courses_math_or_english_gateway_NA = { name = "number of non-gateway courses taken this term" }
+num_courses_co_requisite_course_Y = { name = "number of co-requisite courses taken this term" }
+num_courses_co_requisite_course_N = { name = "number of non-co-requsite courses taken this term" }
+num_courses_course_instructor_employment_status_PT = { name = "number of courses taken this term with a part-time instructor" }
+num_courses_course_instructor_employment_status_FT = { name = "number of courses taken this term with a full-time instructor" }
+num_courses_course_instructor_rank_1 = { name = "number of courses taken this term with an instructor (rank 1)" }
+num_courses_course_instructor_rank_2 = { name = "number of courses taken this term with a lecturer (rank 2)" }
+num_courses_course_instructor_rank_3 = { name = "number of courses taken this term with a senior lecturer (rank 3)" }
+num_courses_course_instructor_rank_4 = { name = "number of courses taken this term with an assistant professor (rank 4)" }
+num_courses_course_instructor_rank_5 = { name = "number of courses taken this term with an associate professor (rank 5)" }
+num_courses_course_instructor_rank_6 = { name = "number of courses taken this term with a professor (rank 6)" }
+num_courses_course_instructor_rank_7 = { name = "number of courses taken this term with an 'other' instructor (rank 7)" }
+num_courses_course_level_1 = { name = "number of level-1 courses taken this term" }
+num_courses_course_level_2 = { name = "number of level-2 courses taken this term" }
+num_courses_course_level_3 = { name = "number of level-3 courses taken this term" }
+num_courses_course_level_4 = { name = "number of level-4 courses taken this term" }
+num_courses_course_level_5 = { name = "number of level-5 courses taken this term" }
+num_courses_course_level_6 = { name = "number of level-6 courses taken this term" }
+num_courses_course_level_7 = { name = "number of level-7 courses taken this term" }
+num_courses_course_level_8 = { name = "number of level-8 courses taken this term" }
+num_courses_course_grade_a = { name = "number of A grades earned this term" }
+num_courses_course_grade_b = { name = "number of B grades earned this term" }
+num_courses_course_grade_c = { name = "number of C grades earned this term" }
+num_courses_course_grade_d = { name = "number of D grades earned this term" }
+num_courses_course_grade_f = { name = "number of F grades earned this term" }
+num_courses_grade_is_failing_or_withdrawal = { name = "number of courses failed or withdrawn this term" }
+num_courses_grade_above_section_avg = { name = "number of courses this term with grades above the sections' avg. grades" }
+cohort_term = { name = "student's cohort (enrollment) term" }
+enrollment_type = { name = "student's enrollment type " }
+enrollment_intensity_first_term = { name = "student's first-term enrollment intensity" }
+math_placement = { name = "TODO" }
+english_placement = { name = "TODO" }
+dual_and_summer_enrollment = { name = "TODO" }
+race = { name = "TODO" }
+ethnicity = { name = "TODO" }
+gender = { name = "TODO" }
+first_gen = { name = "TODO" }
+pell_status_first_year = { name = "TODO" }
+credential_type_sought_year_1 = { name = "TODO" }
+program_of_study_term_1 = { name = "TODO" }
+gpa_group_term_1 = { name = "TODO" }
+gpa_group_year_1 = { name = "TODO" }
+number_of_credits_attempted_year_1 = { name = "TODO" }
+number_of_credits_earned_year_1 = { name = "TODO" }
+number_of_credits_attempted_year_2 = { name = "TODO" }
+number_of_credits_earned_year_2 = { name = "TODO" }
+number_of_credits_attempted_year_3 = { name = "TODO" }
+number_of_credits_earned_year_3 = { name = "TODO" }
+number_of_credits_attempted_year_4 = { name = "TODO" }
+number_of_credits_earned_year_4 = { name = "TODO" }
+reading_placement = { name = "TODO" }
+special_program = { name = "TODO" }
+foreign_language_completion = { name = "TODO" }
+first_year_to_bachelors_at_cohort_inst = { name = "TODO" }
+first_year_to_associates_or_certificate_at_cohort_inst = { name = "TODO" }
+first_year_to_bachelor_at_other_inst = { name = "TODO" }
+first_year_to_associates_or_certificate_at_other_inst = { name = "TODO" }
+program_of_study_year_1 = { name = "TODO" }
+student_program_of_study_area_term_1 = { name = "TODO" }
+student_program_of_study_area_year_1 = { name = "TODO" }
+student_program_of_study_changed_term_1_to_year_1 = { name = "TODO" }
+student_program_of_study_area_changed_term_1_to_year_1 = { name = "TODO" }
+diff_gpa_term_1_to_year_1 = { name = "TODO" }
+frac_credits_earned_year_1 = { name = "TODO" }
+frac_credits_earned_year_2 = { name = "TODO" }
+frac_credits_earned_year_3 = { name = "TODO" }
+frac_credits_earned_year_4 = { name = "TODO" }
+year_of_enrollment_at_cohort_inst = { name = "TODO" }
+term_is_pre_cohort = { name = "TODO" }
+term_is_while_student_enrolled_at_other_inst = { name = "TODO" }
+frac_credits_earned = { name = "TODO" }
+student_term_enrollment_intensity = { name = "TODO" }
+num_courses_in_program_of_study_area_term_1 = { name = "TODO" }
+num_courses_in_program_of_study_area_year_1 = { name = "TODO" }
+frac_courses_passed = { name = "TODO" }
+frac_courses_completed = { name = "TODO" }
+frac_courses_core_course_Y = { name = "TODO" }
+frac_courses_enrolled_at_other_institution_s_Y = { name = "TODO" }
+frac_courses_course_subject_area_51 = { name = "TODO" }
+frac_courses_course_id_ENGLB101 = { name = "TODO" }
+frac_courses_course_id_ENGLB102 = { name = "TODO" }
+frac_courses_course_type_CU = { name = "TODO" }
+frac_courses_course_type_CG = { name = "TODO" }
+frac_courses_course_type_CC = { name = "TODO" }
+frac_courses_course_type_CD = { name = "TODO" }
+frac_courses_course_type_EL = { name = "TODO" }
+frac_courses_course_type_AB = { name = "TODO" }
+frac_courses_course_type_GE = { name = "TODO" }
+frac_courses_course_type_NC = { name = "TODO" }
+frac_courses_course_type_O = { name = "TODO" }
+frac_courses_delivery_method_F = { name = "TODO" }
+frac_courses_delivery_method_O = { name = "TODO" }
+frac_courses_delivery_method_H = { name = "TODO" }
+frac_courses_math_or_english_gateway_M = { name = "TODO" }
+frac_courses_math_or_english_gateway_E = { name = "TODO" }
+frac_courses_math_or_english_gateway_NA = { name = "TODO" }
+frac_courses_co_requisite_course_Y = { name = "TODO" }
+frac_courses_co_requisite_course_N = { name = "TODO" }
+frac_courses_course_instructor_employment_status_PT = { name = "TODO" }
+frac_courses_course_instructor_employment_status_FT = { name = "TODO" }
+frac_courses_course_instructor_rank_1 = { name = "TODO" }
+frac_courses_course_instructor_rank_2 = { name = "TODO" }
+frac_courses_course_instructor_rank_3 = { name = "TODO" }
+frac_courses_course_instructor_rank_4 = { name = "TODO" }
+frac_courses_course_instructor_rank_5 = { name = "TODO" }
+frac_courses_course_instructor_rank_6 = { name = "TODO" }
+frac_courses_course_instructor_rank_7 = { name = "TODO" }
+frac_courses_course_level_1 = { name = "TODO" }
+frac_courses_course_level_2 = { name = "TODO" }
+frac_courses_course_level_3 = { name = "TODO" }
+frac_courses_course_level_4 = { name = "TODO" }
+frac_courses_course_level_5 = { name = "TODO" }
+frac_courses_course_level_6 = { name = "TODO" }
+frac_courses_course_level_7 = { name = "TODO" }
+frac_courses_course_level_8 = { name = "TODO" }
+frac_courses_course_grade_A = { name = "TODO" }
+frac_courses_course_grade_B = { name = "TODO" }
+frac_courses_course_grade_C = { name = "TODO" }
+frac_courses_course_grade_D = { name = "TODO" }
+frac_courses_course_grade_F = { name = "TODO" }
+frac_courses_grade_is_failing_or_withdrawal = { name = "TODO" }
+frac_courses_grade_above_section_avg = { name = "TODO" }
+frac_sections_students_passed = { name = "TODO" }
+frac_sections_students_completed = { name = "TODO" }
+student_pass_rate_above_sections_avg = { name = "TODO" }
+student_completion_rate_above_sections_avg = { name = "TODO" }
+cumnum_unique_course_ids = { name = "TODO" }
+cumnum_unique_course_subjects = { name = "TODO" }
+cumnum_unique_course_subject_areas = { name = "TODO" }
+cumnum_repeated_course_ids = { name = "TODO" }
+cumnum_repeated_course_subjects = { name = "TODO" }
+cumnum_repeated_course_subject_areas = { name = "TODO" }
+cumnum_terms_enrolled = { name = "TODO" }
+term_in_peak_covid_cumsum = { name = "TODO" }
+cumnum_fall_spring_terms_enrolled = { name = "TODO" }
+term_is_while_student_enrolled_at_other_inst_cumsum = { name = "TODO" }
+term_is_pre_cohort_cumsum = { name = "TODO" }
+course_level_mean_cummean = { name = "TODO" }
+course_level_mean_cummin = { name = "TODO" }
+course_level_mean_cumstd = { name = "TODO" }
+course_grade_numeric_mean_cummean = { name = "TODO" }
+course_grade_numeric_mean_cummin = { name = "TODO" }
+course_grade_numeric_mean_cumstd = { name = "TODO" }
+num_courses_cumsum = { name = "TODO" }
+num_courses_cummean = { name = "TODO" }
+num_courses_cummin = { name = "TODO" }
+num_credits_attempted_cumsum = { name = "TODO" }
+num_credits_attempted_cummean = { name = "TODO" }
+num_credits_attempted_cummin = { name = "TODO" }
+num_credits_earned_cumsum = { name = "TODO" }
+num_credits_earned_cummean = { name = "TODO" }
+num_credits_earned_cummin = { name = "TODO" }
+student_pass_rate_above_sections_avg_cumsum = { name = "TODO" }
+student_completion_rate_above_sections_avg_cumsum = { name = "TODO" }
+num_courses_passed_cumfrac = { name = "TODO" }
+num_courses_completed_cumfrac = { name = "TODO" }
+num_courses_core_course_Y_cumfrac = { name = "TODO" }
+num_courses_enrolled_at_other_institution_s_Y_cumfrac = { name = "TODO" }
+num_courses_course_subject_area_51_cumfrac = { name = "TODO" }
+num_courses_course_id_ENGLB101_cumfrac = { name = "TODO" }
+num_courses_course_id_ENGLB102_cumfrac = { name = "TODO" }
+num_courses_course_type_CU_cumfrac = { name = "TODO" }
+num_courses_course_type_CG_cumfrac = { name = "TODO" }
+num_courses_course_type_CC_cumfrac = { name = "TODO" }
+num_courses_course_type_CD_cumfrac = { name = "TODO" }
+num_courses_course_type_EL_cumfrac = { name = "TODO" }
+num_courses_course_type_AB_cumfrac = { name = "TODO" }
+num_courses_course_type_GE_cumfrac = { name = "TODO" }
+num_courses_course_type_NC_cumfrac = { name = "TODO" }
+num_courses_course_type_O_cumfrac = { name = "TODO" }
+num_courses_delivery_method_F_cumfrac = { name = "TODO" }
+num_courses_delivery_method_O_cumfrac = { name = "TODO" }
+num_courses_delivery_method_H_cumfrac = { name = "TODO" }
+num_courses_math_or_english_gateway_M_cumfrac = { name = "TODO" }
+num_courses_math_or_english_gateway_E_cumfrac = { name = "TODO" }
+num_courses_math_or_english_gateway_NA_cumfrac = { name = "TODO" }
+num_courses_co_requisite_course_Y_cumfrac = { name = "TODO" }
+num_courses_co_requisite_course_N_cumfrac = { name = "TODO" }
+num_courses_course_instructor_employment_status_PT_cumfrac = { name = "TODO" }
+num_courses_course_instructor_employment_status_FT_cumfrac = { name = "TODO" }
+num_courses_course_instructor_rank_1_cumfrac = { name = "TODO" }
+num_courses_course_instructor_rank_2_cumfrac = { name = "TODO" }
+num_courses_course_instructor_rank_3_cumfrac = { name = "TODO" }
+num_courses_course_instructor_rank_4_cumfrac = { name = "TODO" }
+num_courses_course_instructor_rank_5_cumfrac = { name = "TODO" }
+num_courses_course_instructor_rank_6_cumfrac = { name = "TODO" }
+num_courses_course_instructor_rank_7_cumfrac = { name = "TODO" }
+num_courses_course_level_1_cumfrac = { name = "TODO" }
+num_courses_course_level_2_cumfrac = { name = "TODO" }
+num_courses_course_level_3_cumfrac = { name = "TODO" }
+num_courses_course_level_4_cumfrac = { name = "TODO" }
+num_courses_course_level_5_cumfrac = { name = "TODO" }
+num_courses_course_level_6_cumfrac = { name = "TODO" }
+num_courses_course_level_7_cumfrac = { name = "TODO" }
+num_courses_course_level_8_cumfrac = { name = "TODO" }
+num_courses_course_grade_A_cumfrac = { name = "TODO" }
+num_courses_course_grade_B_cumfrac = { name = "TODO" }
+num_courses_course_grade_C_cumfrac = { name = "TODO" }
+num_courses_course_grade_D_cumfrac = { name = "TODO" }
+num_courses_course_grade_F_cumfrac = { name = "TODO" }
+num_courses_grade_is_failing_or_withdrawal_cumfrac = { name = "TODO" }
+num_courses_grade_above_section_avg_cumfrac = { name = "TODO" }
+num_courses_in_program_of_study_area_term_1_cumfrac = { name = "TODO" }
+num_courses_in_program_of_study_area_year_1_cumfrac = { name = "TODO" }
+cumfrac_terms_unenrolled = { name = "TODO" }
+cumfrac_fall_spring_terms_unenrolled = { name = "TODO" }
+num_courses_diff_prev_term = { name = "TODO" }
+num_credits_earned_diff_prev_term = { name = "TODO" }
+course_grade_numeric_mean_diff_prev_term = { name = "TODO" }
+num_courses_diff_term_1_to_term_2 = { name = "TODO" }
+num_courses_diff_term_2_to_term_3 = { name = "TODO" }
+num_courses_diff_term_3_to_term_4 = { name = "TODO" }
+num_credits_earned_diff_term_1_to_term_2 = { name = "TODO" }
+num_credits_earned_diff_term_2_to_term_3 = { name = "TODO" }
+num_credits_earned_diff_term_3_to_term_4 = { name = "TODO" }
+course_grade_numeric_mean_diff_term_1_to_term_2 = { name = "TODO" }
+course_grade_numeric_mean_diff_term_2_to_term_3 = { name = "TODO" }
+course_grade_numeric_mean_diff_term_3_to_term_4 = { name = "TODO" }
+"num_courses_course_type_CC|CD" = { name = "TODO" }
+"frac_courses_course_type_CC|CD" = { name = "TODO" }
+"num_courses_course_type_CC|CD_cumfrac" = { name = "TODO" }

--- a/src/student_success_tool/modeling/__init__.py
+++ b/src/student_success_tool/modeling/__init__.py
@@ -1,1 +1,1 @@
-from . import evaluation, feature_selection, inference, training
+from . import evaluation, feature_selection, inference, training, utils

--- a/src/student_success_tool/modeling/inference.py
+++ b/src/student_success_tool/modeling/inference.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import numpy as np
 import pandas as pd
 
@@ -8,6 +10,7 @@ def select_top_features_for_display(
     predicted_probabilities: list[float],
     shap_values: pd.Series,
     n_features: int = 3,
+    features_table: t.Optional[dict[str, dict[str, str]]] = None,
 ) -> pd.DataFrame:
     """
     Select most important features from SHAP for each student
@@ -20,6 +23,8 @@ def select_top_features_for_display(
             order as unique_ids, of shape len(unique_ids)
         shap_values: array of arrays of SHAP values, of shape len(unique_ids)
         n_features: number of important features to return
+        features_table: Optional mapping of column to human-friendly feature name/desc,
+            loaded via :func:`utils.load_features_table()`
 
     Returns:
         explainability dataframe for display
@@ -40,11 +45,16 @@ def select_top_features_for_display(
         for rank, (feature, feature_value, shap_value) in enumerate(
             zip(top_features, top_feature_values, top_shap_values), start=1
         ):
+            feature_name = (
+                features_table.get(feature, {}).get("name", feature)
+                if features_table is not None
+                else feature
+            )
             top_features_info.append(
                 {
                     "Student ID": unique_id,
                     "Support Score": predicted_proba,
-                    "Top Indicators": feature,
+                    "Top Indicators": feature_name,
                     "Indicator Value": feature_value,
                     "SHAP Value": shap_value,
                     "Rank": rank,

--- a/src/student_success_tool/modeling/inference.py
+++ b/src/student_success_tool/modeling/inference.py
@@ -46,7 +46,10 @@ def select_top_features_for_display(
             zip(top_features, top_feature_values, top_shap_values), start=1
         ):
             feature_name = (
-                features_table.get(feature, {}).get("name", feature)
+                # HACK: lowercase feature column name in features table lookup
+                # TODO: we should *ensure* feature column names are lowercased
+                # before using them in a model; current behavior should be considered a bug
+                features_table.get(feature.lower(), {}).get("name", feature)
                 if features_table is not None
                 else feature
             )

--- a/src/student_success_tool/modeling/inference.py
+++ b/src/student_success_tool/modeling/inference.py
@@ -23,6 +23,8 @@ def select_top_features_for_display(
 
     Returns:
         explainability dataframe for display
+
+    TODO: refactor this functionality so it's vectorized and aggregates by student
     """
     top_features_info = []
 
@@ -32,18 +34,20 @@ def select_top_features_for_display(
         instance_shap_values = shap_values[i]
         top_indices = np.argsort(-np.abs(instance_shap_values))[:n_features]
         top_features = features.columns[top_indices]
+        top_feature_values = features.iloc[i][top_features]
         top_shap_values = instance_shap_values[top_indices]
 
-        for rank, (feature, shap_value) in enumerate(
-            zip(top_features, top_shap_values), start=1
+        for rank, (feature, feature_value, shap_value) in enumerate(
+            zip(top_features, top_feature_values, top_shap_values), start=1
         ):
             top_features_info.append(
                 {
                     "Student ID": unique_id,
                     "Support Score": predicted_proba,
                     "Top Indicators": feature,
+                    "Indicator Value": feature_value,
                     "SHAP Value": shap_value,
                     "Rank": rank,
-                }  # column names defined here https://app.asana.com/0/1206275396780585/1206834683873668/f
+                }
             )
     return pd.DataFrame(top_features_info)

--- a/src/student_success_tool/modeling/utils.py
+++ b/src/student_success_tool/modeling/utils.py
@@ -1,3 +1,4 @@
+import logging
 import pathlib
 import typing as t
 from collections.abc import Sequence
@@ -10,6 +11,9 @@ try:
     import tomllib  # noqa
 except ImportError:  # => PY3.10
     import tomli as tomllib  # noqa
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def compute_dataset_splits(
@@ -81,15 +85,23 @@ def compute_sample_weights(
     )
 
 
-def load_features_table(rel_path: str) -> dict[str, dict[str, str]]:
+def load_features_table(rel_fpath: str) -> dict[str, dict[str, str]]:
+    """
+    Load a features table mapping columns to readable names and (optionally) descriptions
+    from a TOML file located at ``rel_fpath`` within this package.
+
+    Args:
+        rel_fpath: Path to features table TOML file relative to package root;
+            for example: "assets/pdp/features_table.toml".
+    """
     pkg_root_dir = next(
         p
         for p in pathlib.Path(__file__).parents
         if p.parts[-1] == "student_success_tool"
     )
-    print(f"{pkg_root_dir=}")
-    file_path = pkg_root_dir / rel_path
+    file_path = pkg_root_dir / rel_fpath
     with file_path.open(mode="rb") as f:
         features_table = tomllib.load(f)
+    LOGGER.info("loaded features table from '%s'", file_path)
     assert isinstance(features_table, dict)  # type guard
     return features_table

--- a/src/student_success_tool/modeling/utils.py
+++ b/src/student_success_tool/modeling/utils.py
@@ -1,9 +1,15 @@
+import pathlib
 import typing as t
 from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
 import sklearn.utils
+
+try:
+    import tomllib  # noqa
+except ImportError:  # => PY3.10
+    import tomli as tomllib  # noqa
 
 
 def compute_dataset_splits(
@@ -73,3 +79,17 @@ def compute_sample_weights(
         dtype="float32",
         name="sample_weight",
     )
+
+
+def load_features_table(rel_path: str) -> dict[str, dict[str, str]]:
+    pkg_root_dir = next(
+        p
+        for p in pathlib.Path(__file__).parents
+        if p.parts[-1] == "student_success_tool"
+    )
+    print(f"{pkg_root_dir=}")
+    file_path = pkg_root_dir / rel_path
+    with file_path.open(mode="rb") as f:
+        features_table = tomllib.load(f)
+    assert isinstance(features_table, dict)  # type guard
+    return features_table

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -2,283 +2,116 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from student_success_tool.modeling.inference import (
-    select_top_features_for_display,
+from student_success_tool.modeling.inference import select_top_features_for_display
+
+
+@pytest.mark.parametrize(
+    [
+        "features",
+        "unique_ids",
+        "predicted_probabilities",
+        "shap_values",
+        "n_features",
+        "features_table",
+        "exp",
+    ],
+    [
+        (
+            pd.DataFrame(
+                {
+                    "x1": ["val1", "val2", "val3"],
+                    "x2": [True, False, True],
+                    "x3": [2.0, 1.0, 0.5],
+                    "x4": [1, 2, 3],
+                }
+            ),
+            pd.Series([1, 2, 3]),
+            [0.9, 0.1, 0.5],
+            np.array(
+                [[1.0, 0.9, 0.8, 0.7], [0.0, -1.0, 0.9, -0.8], [0.25, 0.0, -0.5, 0.75]]
+            ),
+            3,
+            {
+                "x1": {"name": "feature #1"},
+                "x2": {"name": "feature #2"},
+                "x3": {"name": "feature #3"},
+            },
+            pd.DataFrame(
+                {
+                    "Student ID": [1, 1, 1, 2, 2, 2, 3, 3, 3],
+                    "Support Score": [0.9, 0.9, 0.9, 0.1, 0.1, 0.1, 0.5, 0.5, 0.5],
+                    "Top Indicators": [
+                        "feature #1",
+                        "feature #2",
+                        "feature #3",
+                        "feature #2",
+                        "feature #3",
+                        "x4",
+                        "x4",
+                        "feature #3",
+                        "feature #1",
+                    ],
+                    "Indicator Value": [
+                        "val1",
+                        True,
+                        2.0,
+                        False,
+                        1.0,
+                        2,
+                        3,
+                        0.5,
+                        "val3",
+                    ],
+                    "SHAP Value": [1.0, 0.9, 0.8, -1.0, 0.9, -0.8, 0.75, -0.5, 0.25],
+                    "Rank": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+                }
+            ),
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "x1": ["val1", "val2", "val3"],
+                    "x2": [True, False, True],
+                    "x3": [2.0, 1.0, 0.5],
+                    "x4": [1, 2, 3],
+                }
+            ),
+            pd.Series([1, 2, 3]),
+            [0.9, 0.1, 0.5],
+            np.array(
+                [[1.0, 0.9, 0.8, 0.7], [0.0, -1.0, 0.9, -0.8], [0.25, 0.0, -0.5, 0.75]]
+            ),
+            1,
+            None,
+            pd.DataFrame(
+                {
+                    "Student ID": [1, 2, 3],
+                    "Support Score": [0.9, 0.1, 0.5],
+                    "Top Indicators": ["x1", "x2", "x4"],
+                    "Indicator Value": ["val1", False, 3],
+                    "SHAP Value": [1.0, -1.0, 0.75],
+                    "Rank": [1, 1, 1],
+                }
+            ),
+        ),
+    ],
 )
-
-
-# Set up the common data as fixtures in pytest
-@pytest.fixture(scope="module")
-def predicted_probabilities():
-    return [0.96375323, 0.33946405, 0.07414102]
-
-
-@pytest.fixture(scope="module")
-def features():
-    return pd.DataFrame(
-        {
-            "FULL_TIME_ONLY_TERMS": [0, 0, 0],
-            "PART_TIME_ONLY_TERMS": [0, 0, 0],
-            "BOTH_FULL_PART_TIME_TERMS": [1, 1, 1],
-            "FRACTION_FULL_TIME_TERMS": [0.67, 0.71, 0.6],
-            "TOTAL_FAILED_HOURS": [49.0, 4.5, 0.0],
-            "TOTAL_EXCLUDED_HOURS": [39.0, 16.5, 0.0],
-            "TOTAL_HOURS_ENROLLED": [61.0, 78.5, 47.0],
-            "TOTAL_PASSED_HOURS": [12.0, 74.0, 47.0],
-            "CREDITS_HOURS_SEMESTER_COMPLETED_PERF_SUM": [47.0, 74.0, 47.0],
-            "AVG_CREDITS_SEM_COMPLETED": [7.83, 10.6, 9.4],
-            "STDEV_CREDITS_SEM": [4.67, 4.43, 5.50],
-            "COURSE_PASS_RATE": [0.19, 0.94, 1.0],
-            "CREDITS_ENROLLED_LAST_SEM": [7.0, 14.0, 9.0],
-            "CREDITS_ENROLLED_LAST_2_SEM": [19.0, 21.0, 22.0],
-            "CREDITS_ENROLLED_LAST_3_SEM": [30.0, 35.0, 34.0],
-            "CREDITS_ENROLLED_LAST_4_SEM": [35.0, 50.0, 47.0],
-            "HAS_ANY_FINANCIAL_AID": [1, 0, 1],
-            "IR_TOTAL_FA_AWD_AMT_SUM": [0.0, 0.0, 10106.5],
-            "IR_TOTAL_GRANTS_NB_AWD_AMT_SUM": [0.0, 0.0, 7291.5],
-            "IR_STUDENT_LOANS_NB_AWD_AMT_SUM": [0.0, 0.0, 0.0],
-            "IR_FED_WORK_STUDY_NB_AWD_AMT_SUM": [0.0, 0.0, 0.0],
-            "PELL_AMOUNT_AWARD_SUM": [2155.0, 0.0, 797.5],
-            "TAP_AMOUNT_AWARD_SUM": [635.0, 0.0, 1019.5],
-            "PELL_FLAG_COUNT": [1, 0, 2],
-            "TAP_FLAG_COUNT": [2, 0, 2],
-            "PELL_TO_TAP_AMOUNT_RATIO": [3.40, 2.41, 0.78],
-            "PELL_TO_TAP_COUNT_RATIO": [0.5, 1.31, 1.0],
-            "GPA_SEMESTER_AVERAGE": [0.96, 3.23, 3.94],
-            "GPA_SEMESTER_MIN": [0.0, 2.56, 3.83],
-            "GPA_SEMESTER_STDEV": [1.69, 0.37, 0.0804],
-            "GPA_LAST_SEM": [0.0, 3.15, 4.0],
-            "GPA_LAST_2_SEM": [0.0, 2.85, 4.0],
-            "GPA_LAST_3_SEM": [0.0, 2.97, 3.94],
-            "GPA_LAST_4_SEM": [0.0, 3.07, 3.94],
-            "YEARS_ENROLLED": [2.42, 2.25, 1.67],
-            "MAJOR_CHANGES_NUM": [2.0, 0.0, 0.0],
-            "HAS_ASSOCIATE_DEGREE": [0, 1, 1],
-            "IS_JUSTICE_ACADEMY": [0, 1, 1],
-        }
-    )
-
-
-@pytest.fixture(scope="module")
-def unique_ids():
-    return pd.Series([1, 2, 3])
-
-
-@pytest.fixture(scope="module")
-def shap_values():
-    return np.array(
-        [
-            [
-                0.011118,
-                0.0,
-                0.0907295,  # highest
-                0.00252756,
-                0.00398351,
-                0.01459706,
-                -0.00812746,
-                0.00510075,
-                -0.00110377,
-                0.0,
-                0.01422942,
-                0.03684777,
-                0.0345322,
-                0.02334324,
-                0.05655583,  # second
-                0.0286916,
-                0.01193176,
-                -0.01909896,
-                0.03867024,
-                0.0,
-                0.0,
-                0.01072554,
-                0.00422347,
-                0.05371293,  # third
-                0.01439325,
-                0.0,
-                -0.00218049,
-                -0.00182518,
-                0.0,
-                0.0,
-                0.00295084,
-                0.00025675,
-                -0.00991723,
-                0.02664684,
-                0.01449639,
-                -0.00168721,
-                0.01817514,
-                0.03013451,
-            ],
-            [
-                -0.00854077,
-                0.0,
-                -0.04005222,
-                0.0,
-                -0.00274858,
-                -0.00887971,
-                0.00842682,
-                -0.00609056,
-                0.0,
-                0.0,
-                -0.00404544,
-                -0.01132483,
-                -0.0113697,
-                -0.00791739,
-                -0.01783329,
-                -0.00582056,
-                -0.00432695,
-                0.03870561,
-                -0.02091931,
-                0.0,
-                0.0,
-                0.00922927,
-                0.00562887,
-                -0.02678826,
-                -0.00872366,
-                0.0,
-                0.0,
-                -0.01235557,
-                0.0,
-                -0.00083218,
-                0.0031343,
-                0.0018543,
-                0.02105921,
-                -0.00287067,
-                -0.00350567,
-                0.00211131,
-                -0.01648527,
-                0.01162551,
-            ],
-            [
-                0.0,
-                0.0,
-                -0.048401,
-                -0.00038467,
-                -0.00066859,
-                -0.00465909,
-                -0.00230638,
-                0.0032778,
-                0.0,
-                0.0,
-                -0.01026985,
-                -0.02532982,
-                -0.02460769,
-                -0.01557121,
-                -0.04024391,
-                -0.02144066,
-                -0.00647471,
-                -0.0204918,
-                -0.01930845,
-                0.0,
-                0.0,
-                -0.02129827,
-                -0.01246468,
-                -0.02635055,
-                -0.00554038,
-                0.0,
-                0.0,
-                0.01185864,
-                -0.00036082,
-                -0.00020721,
-                -0.00518232,
-                -0.00083516,
-                -0.01189103,
-                -0.01975234,
-                -0.013319,
-                -0.00083572,
-                0.0,
-                -0.04191956,
-            ],
-        ]
-    )
-
-
-# # Use the fixtures in your test functions
-# def test_dataframe_with_nan_values(test_df, shap_values):
-#     df_with_nans = test_df.copy()
-#     df_with_nans.iloc[0, df_with_nans.columns.get_loc("TOTAL_FAILED_HOURS")] = np.nan
-#     result_df = select_top_features_for_display(
-#         df_with_nans, shap_values
-#     )
-#     assert not result_df.isnull().values.any()
-
-
-def test_explanation_output_structure(
-    features, unique_ids, predicted_probabilities, shap_values
+def test_select_top_features_for_display(
+    features,
+    unique_ids,
+    predicted_probabilities,
+    shap_values,
+    n_features,
+    features_table,
+    exp,
 ):
-    result_df = select_top_features_for_display(
-        features, unique_ids, predicted_probabilities, shap_values
-    )
-
-    # Basic checks for the result's structure
-    assert isinstance(result_df, pd.DataFrame)
-    assert "Student ID" in result_df.columns
-    assert "Support Score" in result_df.columns
-    assert "Top Indicators" in result_df.columns
-    assert "SHAP Value" in result_df.columns
-    assert "Rank" in result_df.columns
-
-    # Check if the output DataFrame contains the expected number of rows
-    expected_rows = len(features) * 3
-    assert len(result_df) == expected_rows
-
-    sorted_results = result_df.sort_values(["Student ID", "Rank"])
-    assert sorted_results[sorted_results["Student ID"] == 1][
-        "Top Indicators"
-    ].tolist() == [
-        "BOTH_FULL_PART_TIME_TERMS",
-        "CREDITS_ENROLLED_LAST_3_SEM",
-        "PELL_FLAG_COUNT",
-    ]
-    assert sorted_results[sorted_results["Student ID"] == 2][
-        "Top Indicators"
-    ].tolist() == [
-        "BOTH_FULL_PART_TIME_TERMS",
-        "IR_TOTAL_FA_AWD_AMT_SUM",
-        "PELL_FLAG_COUNT",
-    ]
-    assert sorted_results[sorted_results["Student ID"] == 3][
-        "Top Indicators"
-    ].tolist() == [
-        "BOTH_FULL_PART_TIME_TERMS",
-        "IS_JUSTICE_ACADEMY",
-        "CREDITS_ENROLLED_LAST_3_SEM",
-    ]
-
-
-def test_explanation_output_structure_with_features_table(
-    features, unique_ids, predicted_probabilities, shap_values
-):
-    features_table = {
-        "both_full_part_time_terms": {"name": "both full part time terms"},
-        "credits_enrolled_last_3_sem": {
-            "name": "number of credits enrolled in last 3 terms"
-        },
-    }
-    result_df = select_top_features_for_display(
+    obs = select_top_features_for_display(
         features,
         unique_ids,
         predicted_probabilities,
         shap_values,
+        n_features=n_features,
         features_table=features_table,
     )
-
-    # Basic checks for the result's structure
-    assert isinstance(result_df, pd.DataFrame)
-    assert "Student ID" in result_df.columns
-    assert "Support Score" in result_df.columns
-    assert "Top Indicators" in result_df.columns
-    assert "SHAP Value" in result_df.columns
-    assert "Rank" in result_df.columns
-
-    # Check if the output DataFrame contains the expected number of rows
-    expected_rows = len(features) * 3
-    assert len(result_df) == expected_rows
-
-    sorted_results = result_df.sort_values(["Student ID", "Rank"])
-    assert sorted_results[sorted_results["Student ID"] == 1][
-        "Top Indicators"
-    ].tolist() == [
-        "both full part time terms",
-        "number of credits enrolled in last 3 terms",
-        "PELL_FLAG_COUNT",
-    ]
+    assert isinstance(obs, pd.DataFrame) and not obs.empty
+    assert pd.testing.assert_frame_equal(obs, exp) is None

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -7,9 +5,6 @@ import pytest
 from student_success_tool.modeling.inference import (
     select_top_features_for_display,
 )
-
-# Ignore warnings that might clutter the output
-warnings.simplefilter(action="ignore")
 
 
 # Set up the common data as fixtures in pytest
@@ -19,53 +14,54 @@ def predicted_probabilities():
 
 
 @pytest.fixture(scope="module")
-def test_data():
-    return {
-        "UNIQUE_ID": [1, 2, 3],
-        "FULL_TIME_ONLY_TERMS": [0, 0, 0],
-        "PART_TIME_ONLY_TERMS": [0, 0, 0],
-        "BOTH_FULL_PART_TIME_TERMS": [1, 1, 1],
-        "FRACTION_FULL_TIME_TERMS": [0.67, 0.71, 0.6],
-        "TOTAL_FAILED_HOURS": [49.0, 4.5, 0.0],
-        "TOTAL_EXCLUDED_HOURS": [39.0, 16.5, 0.0],
-        "TOTAL_HOURS_ENROLLED": [61.0, 78.5, 47.0],
-        "TOTAL_PASSED_HOURS": [12.0, 74.0, 47.0],
-        "CREDITS_HOURS_SEMESTER_COMPLETED_PERF_SUM": [47.0, 74.0, 47.0],
-        "AVG_CREDITS_SEM_COMPLETED": [7.83, 10.6, 9.4],
-        "STDEV_CREDITS_SEM": [4.67, 4.43, 5.50],
-        "COURSE_PASS_RATE": [0.19, 0.94, 1.0],
-        "CREDITS_ENROLLED_LAST_SEM": [7.0, 14.0, 9.0],
-        "CREDITS_ENROLLED_LAST_2_SEM": [19.0, 21.0, 22.0],
-        "CREDITS_ENROLLED_LAST_3_SEM": [30.0, 35.0, 34.0],
-        "CREDITS_ENROLLED_LAST_4_SEM": [35.0, 50.0, 47.0],
-        "HAS_ANY_FINANCIAL_AID": [1, 0, 1],
-        "IR_TOTAL_FA_AWD_AMT_SUM": [0.0, 0.0, 10106.5],
-        "IR_TOTAL_GRANTS_NB_AWD_AMT_SUM": [0.0, 0.0, 7291.5],
-        "IR_STUDENT_LOANS_NB_AWD_AMT_SUM": [0.0, 0.0, 0.0],
-        "IR_FED_WORK_STUDY_NB_AWD_AMT_SUM": [0.0, 0.0, 0.0],
-        "PELL_AMOUNT_AWARD_SUM": [2155.0, 0.0, 797.5],
-        "TAP_AMOUNT_AWARD_SUM": [635.0, 0.0, 1019.5],
-        "PELL_FLAG_COUNT": [1, 0, 2],
-        "TAP_FLAG_COUNT": [2, 0, 2],
-        "PELL_TO_TAP_AMOUNT_RATIO": [3.40, 2.41, 0.78],
-        "PELL_TO_TAP_COUNT_RATIO": [0.5, 1.31, 1.0],
-        "GPA_SEMESTER_AVERAGE": [0.96, 3.23, 3.94],
-        "GPA_SEMESTER_MIN": [0.0, 2.56, 3.83],
-        "GPA_SEMESTER_STDEV": [1.69, 0.37, 0.0804],
-        "GPA_LAST_SEM": [0.0, 3.15, 4.0],
-        "GPA_LAST_2_SEM": [0.0, 2.85, 4.0],
-        "GPA_LAST_3_SEM": [0.0, 2.97, 3.94],
-        "GPA_LAST_4_SEM": [0.0, 3.07, 3.94],
-        "YEARS_ENROLLED": [2.42, 2.25, 1.67],
-        "MAJOR_CHANGES_NUM": [2.0, 0.0, 0.0],
-        "HAS_ASSOCIATE_DEGREE": [0, 1, 1],
-        "IS_JUSTICE_ACADEMY": [0, 1, 1],
-    }
+def features():
+    return pd.DataFrame(
+        {
+            "FULL_TIME_ONLY_TERMS": [0, 0, 0],
+            "PART_TIME_ONLY_TERMS": [0, 0, 0],
+            "BOTH_FULL_PART_TIME_TERMS": [1, 1, 1],
+            "FRACTION_FULL_TIME_TERMS": [0.67, 0.71, 0.6],
+            "TOTAL_FAILED_HOURS": [49.0, 4.5, 0.0],
+            "TOTAL_EXCLUDED_HOURS": [39.0, 16.5, 0.0],
+            "TOTAL_HOURS_ENROLLED": [61.0, 78.5, 47.0],
+            "TOTAL_PASSED_HOURS": [12.0, 74.0, 47.0],
+            "CREDITS_HOURS_SEMESTER_COMPLETED_PERF_SUM": [47.0, 74.0, 47.0],
+            "AVG_CREDITS_SEM_COMPLETED": [7.83, 10.6, 9.4],
+            "STDEV_CREDITS_SEM": [4.67, 4.43, 5.50],
+            "COURSE_PASS_RATE": [0.19, 0.94, 1.0],
+            "CREDITS_ENROLLED_LAST_SEM": [7.0, 14.0, 9.0],
+            "CREDITS_ENROLLED_LAST_2_SEM": [19.0, 21.0, 22.0],
+            "CREDITS_ENROLLED_LAST_3_SEM": [30.0, 35.0, 34.0],
+            "CREDITS_ENROLLED_LAST_4_SEM": [35.0, 50.0, 47.0],
+            "HAS_ANY_FINANCIAL_AID": [1, 0, 1],
+            "IR_TOTAL_FA_AWD_AMT_SUM": [0.0, 0.0, 10106.5],
+            "IR_TOTAL_GRANTS_NB_AWD_AMT_SUM": [0.0, 0.0, 7291.5],
+            "IR_STUDENT_LOANS_NB_AWD_AMT_SUM": [0.0, 0.0, 0.0],
+            "IR_FED_WORK_STUDY_NB_AWD_AMT_SUM": [0.0, 0.0, 0.0],
+            "PELL_AMOUNT_AWARD_SUM": [2155.0, 0.0, 797.5],
+            "TAP_AMOUNT_AWARD_SUM": [635.0, 0.0, 1019.5],
+            "PELL_FLAG_COUNT": [1, 0, 2],
+            "TAP_FLAG_COUNT": [2, 0, 2],
+            "PELL_TO_TAP_AMOUNT_RATIO": [3.40, 2.41, 0.78],
+            "PELL_TO_TAP_COUNT_RATIO": [0.5, 1.31, 1.0],
+            "GPA_SEMESTER_AVERAGE": [0.96, 3.23, 3.94],
+            "GPA_SEMESTER_MIN": [0.0, 2.56, 3.83],
+            "GPA_SEMESTER_STDEV": [1.69, 0.37, 0.0804],
+            "GPA_LAST_SEM": [0.0, 3.15, 4.0],
+            "GPA_LAST_2_SEM": [0.0, 2.85, 4.0],
+            "GPA_LAST_3_SEM": [0.0, 2.97, 3.94],
+            "GPA_LAST_4_SEM": [0.0, 3.07, 3.94],
+            "YEARS_ENROLLED": [2.42, 2.25, 1.67],
+            "MAJOR_CHANGES_NUM": [2.0, 0.0, 0.0],
+            "HAS_ASSOCIATE_DEGREE": [0, 1, 1],
+            "IS_JUSTICE_ACADEMY": [0, 1, 1],
+        }
+    )
 
 
 @pytest.fixture(scope="module")
-def test_df(test_data):
-    return pd.DataFrame(test_data)
+def unique_ids():
+    return pd.Series([1, 2, 3])
 
 
 @pytest.fixture(scope="module")
@@ -206,10 +202,11 @@ def shap_values():
 #     assert not result_df.isnull().values.any()
 
 
-def test_explanation_output_structure(test_df, predicted_probabilities, shap_values):
-    features = test_df.drop(columns="UNIQUE_ID")
+def test_explanation_output_structure(
+    features, unique_ids, predicted_probabilities, shap_values
+):
     result_df = select_top_features_for_display(
-        features, test_df["UNIQUE_ID"], predicted_probabilities, shap_values
+        features, unique_ids, predicted_probabilities, shap_values
     )
 
     # Basic checks for the result's structure
@@ -221,7 +218,7 @@ def test_explanation_output_structure(test_df, predicted_probabilities, shap_val
     assert "Rank" in result_df.columns
 
     # Check if the output DataFrame contains the expected number of rows
-    expected_rows = len(test_df) * 3
+    expected_rows = len(features) * 3
     assert len(result_df) == expected_rows
 
     sorted_results = result_df.sort_values(["Student ID", "Rank"])
@@ -245,4 +242,43 @@ def test_explanation_output_structure(test_df, predicted_probabilities, shap_val
         "BOTH_FULL_PART_TIME_TERMS",
         "IS_JUSTICE_ACADEMY",
         "CREDITS_ENROLLED_LAST_3_SEM",
+    ]
+
+
+def test_explanation_output_structure_with_features_table(
+    features, unique_ids, predicted_probabilities, shap_values
+):
+    features_table = {
+        "both_full_part_time_terms": {"name": "both full part time terms"},
+        "credits_enrolled_last_3_sem": {
+            "name": "number of credits enrolled in last 3 terms"
+        },
+    }
+    result_df = select_top_features_for_display(
+        features,
+        unique_ids,
+        predicted_probabilities,
+        shap_values,
+        features_table=features_table,
+    )
+
+    # Basic checks for the result's structure
+    assert isinstance(result_df, pd.DataFrame)
+    assert "Student ID" in result_df.columns
+    assert "Support Score" in result_df.columns
+    assert "Top Indicators" in result_df.columns
+    assert "SHAP Value" in result_df.columns
+    assert "Rank" in result_df.columns
+
+    # Check if the output DataFrame contains the expected number of rows
+    expected_rows = len(features) * 3
+    assert len(result_df) == expected_rows
+
+    sorted_results = result_df.sort_values(["Student ID", "Rank"])
+    assert sorted_results[sorted_results["Student ID"] == 1][
+        "Top Indicators"
+    ].tolist() == [
+        "both full part time terms",
+        "number of credits enrolled in last 3 terms",
+        "PELL_FLAG_COUNT",
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -2671,6 +2671,7 @@ dependencies = [
     { name = "seaborn" },
     { name = "shap" },
     { name = "statsmodels" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -2700,6 +2701,7 @@ requires-dist = [
     { name = "seaborn", specifier = "~=0.13" },
     { name = "shap", specifier = "~=0.46.0" },
     { name = "statsmodels", specifier = "~=0.14" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = "~=2.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds `tomli` as optional project dependency (for PY3.10 only)
- adds "assets" directory, and within it, adds a "features table" toml file mapping PDP column names to human-friendly feature names (and, eventually, fuller descriptions)
- adds a utils func to load+parse features tables from disk
- adds feature values to inference topn feature display function (ported from https://github.com/datakind/student-success-intervention/pull/120) and also optional feature name mapping by way of a features table

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

PDP's internal feature column naming is a bit... technical. Advisors need more friendly naming to help them interpret model outputs correctly.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- Does this seem like a reasonable implementation?
- How do y'all feel about [TOML](https://toml.io/en/)? Personally I love it, and much prefer it over YAML. :D