### PR TITLE
[pdp] Add project config functionality

### DIFF
--- a/notebooks/pdp/02-prepare-modeling-dataset-TEMPLATE.py
+++ b/notebooks/pdp/02-prepare-modeling-dataset-TEMPLATE.py
@@ -39,6 +39,7 @@ import pandas as pd
 import seaborn as sb
 from databricks.connect import DatabricksSession
 
+from student_success_tool import configs
 from student_success_tool.analysis import pdp
 
 # COMMAND ----------
@@ -74,7 +75,13 @@ from analysis import *  # noqa: F403
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Unity Catalog config
+# MAGIC ## project config
+
+# COMMAND ----------
+
+# TODO: create a config file in TOML format to school directory
+config = configs.load_config("./config.toml", schema=configs.PDPProjectConfig)
+config
 
 # COMMAND ----------
 
@@ -123,24 +130,18 @@ df_cohort.head()
 
 # COMMAND ----------
 
-# school-specific parameters that configure featurization code
-# these should all be changed, as desired, and confirmed with client stakeholders
-min_passing_grade = pdp.constants.DEFAULT_MIN_PASSING_GRADE
-min_num_credits_full_time = pdp.constants.DEFAULT_MIN_NUM_CREDITS_FULL_TIME
-course_level_pattern = pdp.constants.DEFAULT_COURSE_LEVEL_PATTERN
-key_course_subject_areas = None
-key_course_ids = None
+dict(config.prepare_modeling_dataset)
 
 # COMMAND ----------
 
 df_student_terms = pdp.dataops.make_student_term_dataset(
     df_cohort,
     df_course,
-    min_passing_grade=min_passing_grade,
-    min_num_credits_full_time=min_num_credits_full_time,
-    course_level_pattern=course_level_pattern,
-    key_course_subject_areas=key_course_subject_areas,
-    key_course_ids=key_course_ids,
+    min_passing_grade=config.prepare_modeling_dataset.min_passing_grade,
+    min_num_credits_full_time=config.prepare_modeling_dataset.min_num_credits_full_time,
+    course_level_pattern=config.prepare_modeling_dataset.course_level_pattern,
+    key_course_subject_areas=config.prepare_modeling_dataset.key_course_subject_areas,
+    key_course_ids=config.prepare_modeling_dataset.key_course_ids,
 )
 df_student_terms
 
@@ -313,5 +314,3 @@ target_assocs
 # MAGIC # Wrap-up
 # MAGIC
 # MAGIC TODO
-
-# COMMAND ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pandas~=2.1",
     "pandera~=0.21",
     "pyarrow~=16.0",
+    "pydantic~=2.10",
     "pyyaml~=6.0",
     "scikit-learn~=1.4",
     "seaborn~=0.13",

--- a/src/student_success_tool/configs/__init__.py
+++ b/src/student_success_tool/configs/__init__.py
@@ -1,0 +1,2 @@
+from .load import load_config
+from .schemas.pdp import PDPProjectConfig

--- a/src/student_success_tool/configs/load.py
+++ b/src/student_success_tool/configs/load.py
@@ -1,0 +1,21 @@
+import logging
+import pathlib
+
+import pydantic as pyd
+
+try:
+    import tomllib  # noqa
+except ImportError:  # => PY3.10
+    import tomli as tomllib  # noqa
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def load_config(file_path: str, schema: pyd.BaseModel) -> pyd.BaseModel:
+    fpath = pathlib.Path(file_path).resolve()
+    with fpath.open(mode="rb") as f:
+        config = tomllib.load(f)
+    LOGGER.info("loaded config from '%s'", fpath)
+    assert isinstance(config, dict)  # type guard
+    return schema.model_validate(config)

--- a/src/student_success_tool/configs/load.py
+++ b/src/student_success_tool/configs/load.py
@@ -13,6 +13,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 def load_config(file_path: str, schema: pyd.BaseModel) -> pyd.BaseModel:
+    """
+    Load config from ``file_path`` and validate it using ``schema`` ,
+    returning an instance with configuration fields accessible by attribute.
+    """
     fpath = pathlib.Path(file_path).resolve()
     with fpath.open(mode="rb") as f:
         config = tomllib.load(f)

--- a/src/student_success_tool/configs/schemas/pdp.py
+++ b/src/student_success_tool/configs/schemas/pdp.py
@@ -1,0 +1,139 @@
+import typing as t
+
+import pydantic as pyd
+
+from ...analysis.pdp import constants
+
+
+class PrepareModelingDatasetConfig(pyd.BaseModel):
+    min_passing_grade: float = pyd.Field(
+        default=constants.DEFAULT_MIN_PASSING_GRADE,
+        description="Minimum numeric grade considered by institution as 'passing'",
+        gt=0.0,
+        lt=4.0,
+    )
+    min_num_credits_full_time: float = pyd.Field(
+        default=constants.DEFAULT_MIN_NUM_CREDITS_FULL_TIME,
+        description=(
+            "Minimum number of credits *attempted* per term for a student's "
+            "enrollment intensity to be considered 'full-time'."
+        ),
+        gt=0.0,
+        lt=20.0,
+    )
+    course_level_pattern: str = pyd.Field(
+        default=constants.DEFAULT_COURSE_LEVEL_PATTERN,
+        description=(
+            "Regular expression patttern that extracts a course's 'level' "
+            "from a PDP course_number field"
+        ),
+    )
+    peak_covid_terms: set[tuple[str, str]] = pyd.Field(
+        default=constants.DEFAULT_PEAK_COVID_TERMS,
+        description=(
+            "Set of (academic year, academic term) pairs considered by institution "
+            "as 'peak' COVID, for use in control variables to account for pandemic effects"
+        ),
+    )
+    key_course_subject_areas: t.Optional[list[str]] = pyd.Field(
+        default=None,
+        description=(
+            "One or more course subject areas (formatted as 2-digit CIP codes) "
+            "for which custom features should be computed"
+        ),
+    )
+    key_course_ids: t.Optional[list[str]] = pyd.Field(
+        default=None,
+        description=(
+            "One or more course ids (formatted as '[COURSE_PREFIX][COURSE_NUMBER]') "
+            "for which custom features should be computed"
+        ),
+    )
+    target_student_criteria: dict[str, object] = pyd.Field(
+        default_factory=dict,
+        description=(
+            "Column name in modeling dataset mapped to one or more values that it must equal "
+            "in order for the corresponding student to be considered 'eligible'. "
+            "Multiple criteria are combined with a logical 'AND'."
+        ),
+    )
+
+
+class TrainEvaluateModelConfig(pyd.BaseModel):
+    """
+    References:
+        - https://docs.databricks.com/en/machine-learning/automl/automl-api-reference.html#classify
+    """
+
+    dataset_table_path: str = pyd.Field(
+        description=(
+            "Path in Unity Catalog from which modeling dataset will be read, "
+            "including the full three-level namespace: ``catalog.schema.table`` ."
+        )
+    )
+    student_id_col: str = "student_guid"
+    target_col: str = pyd.Field(
+        default="target",
+        description="Column name in dataset for the target label to be predicted.",
+    )
+    split_col: t.Optional[str] = pyd.Field(
+        default=None,
+        description="Column name in dataset for splitting into train/test/validate sets.",
+    )
+    sample_weight_col: t.Optional[str] = pyd.Field(
+        default=None,
+        description=(
+            "Column name in dataset that contains sample weights per row, "
+            "typically used to adjust class importances for imbalanced data."
+        ),
+    )
+    student_group_cols: t.Optional[list[str]] = pyd.Field(
+        default=None,
+        description=(
+            "One or more column names in dataset containing student 'groups' "
+            "to use for model bias assessment, but NOT as model features"
+        ),
+    )
+    exclude_cols: t.Optional[list[str]] = pyd.Field(
+        default=None,
+        description="One or more column names in dataset to exclude from training.",
+    )
+    time_col: t.Optional[str] = pyd.Field(
+        default=None,
+        description=(
+            "Column name in dataset used to split train/test/validate sets chronologically, "
+            "as an alternative to the randomized assignment in ``split_col`` ."
+        ),
+    )
+    pos_label: t.Optional[int | bool | str] = pyd.Field(
+        default=None,
+        description=(
+            "Positive class value in ``target_col`` "
+            "(for binary classification problems only)."
+        ),
+    )
+    exclude_frameworks: t.Optional[list[str]] = pyd.Field(
+        default=None,
+        description="List of algorithm frameworks that AutoML excludes from training.",
+    )
+    primary_metric: str = pyd.Field(
+        default="f1", description="Metric used to evaluate and rank model performance."
+    )
+    timeout_minutes: t.Optional[int] = pyd.Field(
+        default=None,
+        description="Maximum time to wait for AutoML trials to complete.",
+    )
+
+
+class PDPProjectConfig(pyd.BaseModel):
+    """
+    Configuration schema for PDP SST projects, with top-level fields aligned to
+    discrete steps in the SST data+modeling pipeline.
+    """
+
+    model_config = pyd.ConfigDict(extra="ignore", strict=True)
+
+    institution_name: str
+    # TODO: data_assessment_eda: DataAssessmentEDAConfig ?
+    prepare_modeling_dataset: t.Optional[PrepareModelingDatasetConfig] = None
+    train_evaluate_model: t.Optional[TrainEvaluateModelConfig] = None

--- a/uv.lock
+++ b/uv.lock
@@ -2666,11 +2666,13 @@ dependencies = [
     { name = "pandas" },
     { name = "pandera" },
     { name = "pyarrow" },
+    { name = "pydantic" },
     { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "seaborn" },
     { name = "shap" },
     { name = "statsmodels" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -2695,11 +2697,13 @@ requires-dist = [
     { name = "pandas", specifier = "~=2.1" },
     { name = "pandera", specifier = "~=0.21" },
     { name = "pyarrow", specifier = "~=16.0" },
+    { name = "pydantic", specifier = "~=2.10" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "scikit-learn", specifier = "~=1.4" },
     { name = "seaborn", specifier = "~=0.13" },
     { name = "shap", specifier = "~=0.46.0" },
     { name = "statsmodels", specifier = "~=0.14" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = "~=2.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- adds `pydantic` to build dependencies, used to define generic schemas analogously to `pandera` for datasets
- adds `configs` subpackage, with functionality for loading and validating project configuration from a toml file
- adds (first-draft) config schema for PDP projects
- adds example usage to template nb

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

This is a next step in standardizing / productionalizing PDP projects: most functionality being driven by a standard, human-friendly config file. We've long had something like this for model training in the private, school-specific repo, but this generalizes / improves upon the concept.

Builds on PR #43, which introduced toml for feature tables.

[Here](https://github.com/datakind/student-success-intervention/blob/c72f86311e7f088e044e37494a7bbae932007fd8/analysis/uscb/config.toml) is an example config file.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- What do you think of the config schema? Does it make sense / feel intuitive? Is there anything you'd change or that you think is missing? (I have ideas myself, but figured it would be better to share a rough draft to the world before iterating.)