### PR TITLE
Fix pdp gen failure from different institution ids

### DIFF
--- a/scripts/generate_synthetic_pdp_datasets.py
+++ b/scripts/generate_synthetic_pdp_datasets.py
@@ -27,8 +27,7 @@ def main():
     ]
     course_records = [
         FAKER.raw_course_record(
-            cohort_record, normalize_col_names=args.normalize_col_names, institution_id=institution_id
-        )
+            cohort_record, normalize_col_names=args.normalize_col_names)
         for cohort_record in cohort_records
         for _ in range(
             FAKER.randomize_nb_elements(args.avg_num_courses_per_student, min=1)

--- a/scripts/generate_synthetic_pdp_datasets.py
+++ b/scripts/generate_synthetic_pdp_datasets.py
@@ -19,13 +19,15 @@ def main():
     FAKER.add_provider(pdp.raw_cohort.Provider)
     FAKER.add_provider(pdp.raw_course.Provider)
 
+    # institution_id must be the same for all records.
+    institution_id = FAKER.numerify("#####!")
     cohort_records = [
-        FAKER.raw_cohort_record(normalize_col_names=args.normalize_col_names)
+        FAKER.raw_cohort_record(normalize_col_names=args.normalize_col_names, institution_id=institution_id)
         for _ in range(args.num_students)
     ]
     course_records = [
         FAKER.raw_course_record(
-            cohort_record, normalize_col_names=args.normalize_col_names
+            cohort_record, normalize_col_names=args.normalize_col_names, institution_id=institution_id
         )
         for cohort_record in cohort_records
         for _ in range(

--- a/scripts/generate_synthetic_pdp_datasets.py
+++ b/scripts/generate_synthetic_pdp_datasets.py
@@ -22,12 +22,15 @@ def main():
     # institution_id must be the same for all records.
     institution_id = FAKER.numerify("#####!")
     cohort_records = [
-        FAKER.raw_cohort_record(normalize_col_names=args.normalize_col_names, institution_id=institution_id)
+        FAKER.raw_cohort_record(
+            normalize_col_names=args.normalize_col_names, institution_id=institution_id
+        )
         for _ in range(args.num_students)
     ]
     course_records = [
         FAKER.raw_course_record(
-            cohort_record, normalize_col_names=args.normalize_col_names)
+            cohort_record, normalize_col_names=args.normalize_col_names
+        )
         for cohort_record in cohort_records
         for _ in range(
             FAKER.randomize_nb_elements(args.avg_num_courses_per_student, min=1)

--- a/src/student_success_tool/generation/pdp/raw_cohort.py
+++ b/src/student_success_tool/generation/pdp/raw_cohort.py
@@ -12,7 +12,7 @@ class Provider(BaseProvider):
         min_cohort_yr: int = 2010,
         max_cohort_yr: t.Optional[int] = None,
         normalize_col_names: bool = False,
-        institution_id: int = 12345,
+        institution_id: t.Optional[int] = None,
     ) -> dict[str, object]:
         # some fields are inputs to others; compute them first, accordingly
         enrollment_type = self.enrollment_type()
@@ -25,7 +25,7 @@ class Provider(BaseProvider):
         # TODO: handle other cases, e.g. gateway course attempted/completed/grades
         record = {
             "Student GUID": self.student_guid(),
-            "Institution ID": institution_id,
+            "Institution ID": institution_id if institution_id is not None else self.institution_id(),
             "Cohort": self.cohort(min_yr=min_cohort_yr, max_yr=max_cohort_yr),
             "Cohort Term": self.cohort_term(),
             "Student Age": self.student_age(),

--- a/src/student_success_tool/generation/pdp/raw_cohort.py
+++ b/src/student_success_tool/generation/pdp/raw_cohort.py
@@ -22,11 +22,13 @@ class Provider(BaseProvider):
         number_of_credits_attempted_year_3 = self.number_of_credits_attempted_year_3()
         number_of_credits_attempted_year_4 = self.number_of_credits_attempted_year_4()
         _has_enrollment_other_inst: bool = self.generator.random.random() < 0.25
-        
+
         # TODO: handle other cases, e.g. gateway course attempted/completed/grades
         record = {
             "Student GUID": self.student_guid(),
-            "Institution ID": institution_id if institution_id is not None else self.institution_id(),
+            "Institution ID": institution_id
+            if institution_id is not None
+            else self.institution_id(),
             "Cohort": self.cohort(min_yr=min_cohort_yr, max_yr=max_cohort_yr),
             "Cohort Term": self.cohort_term(),
             "Student Age": self.student_age(),

--- a/src/student_success_tool/generation/pdp/raw_cohort.py
+++ b/src/student_success_tool/generation/pdp/raw_cohort.py
@@ -12,6 +12,7 @@ class Provider(BaseProvider):
         min_cohort_yr: int = 2010,
         max_cohort_yr: t.Optional[int] = None,
         normalize_col_names: bool = False,
+        institution_id: int = 12345,
     ) -> dict[str, object]:
         # some fields are inputs to others; compute them first, accordingly
         enrollment_type = self.enrollment_type()
@@ -24,7 +25,7 @@ class Provider(BaseProvider):
         # TODO: handle other cases, e.g. gateway course attempted/completed/grades
         record = {
             "Student GUID": self.student_guid(),
-            "Institution ID": self.institution_id(),
+            "Institution ID": institution_id,
             "Cohort": self.cohort(min_yr=min_cohort_yr, max_yr=max_cohort_yr),
             "Cohort Term": self.cohort_term(),
             "Student Age": self.student_age(),

--- a/src/student_success_tool/generation/pdp/raw_cohort.py
+++ b/src/student_success_tool/generation/pdp/raw_cohort.py
@@ -12,7 +12,7 @@ class Provider(BaseProvider):
         min_cohort_yr: int = 2010,
         max_cohort_yr: t.Optional[int] = None,
         normalize_col_names: bool = False,
-        institution_id: t.Optional[int] = None,
+        institution_id: t.Optional[str] = None,
     ) -> dict[str, object]:
         # some fields are inputs to others; compute them first, accordingly
         enrollment_type = self.enrollment_type()
@@ -22,6 +22,7 @@ class Provider(BaseProvider):
         number_of_credits_attempted_year_3 = self.number_of_credits_attempted_year_3()
         number_of_credits_attempted_year_4 = self.number_of_credits_attempted_year_4()
         _has_enrollment_other_inst: bool = self.generator.random.random() < 0.25
+        
         # TODO: handle other cases, e.g. gateway course attempted/completed/grades
         record = {
             "Student GUID": self.student_guid(),

--- a/src/student_success_tool/generation/pdp/raw_course.py
+++ b/src/student_success_tool/generation/pdp/raw_course.py
@@ -8,7 +8,7 @@ from ...analysis.pdp import utils
 
 class Provider(BaseProvider):
     def raw_course_record(
-        self, cohort_record: t.Optional[dict] = None, normalize_col_names: bool = False
+        self, cohort_record: t.Optional[dict] = None, normalize_col_names: bool = False, institution_id: int = 12345
     ) -> dict[str, object]:
         # use existing values where records overlap
         if cohort_record is not None:
@@ -18,7 +18,6 @@ class Provider(BaseProvider):
             race = cr.get("race", cr["Race"])
             ethnicity = cr.get("ethnicity", cr["Ethnicity"])
             gender = cr.get("gender", cr["Gender"])
-            institution_id = cr.get("institution_id", cr["Institution ID"])
             cohort = cr.get("cohort", cr["Cohort"])
             cohort_term = cr.get("cohort_term", cr["Cohort Term"])
             _has_enrollment_other_inst: bool = (
@@ -34,7 +33,6 @@ class Provider(BaseProvider):
             race = self.race()
             ethnicity = self.ethnicity()
             gender = self.gender()
-            institution_id = self.institution_id()
             cohort = self.cohort()
             cohort_term = self.cohort_term()
             _has_enrollment_other_inst: bool = self.generator.random.random() < 0.25  # type: ignore
@@ -107,9 +105,6 @@ class Provider(BaseProvider):
         return record
 
     def student_guid(self) -> str:
-        return self.numerify("#####!")  # type: ignore
-
-    def institution_id(self) -> str:
         return self.numerify("#####!")  # type: ignore
 
     def student_age(self) -> str:

--- a/src/student_success_tool/generation/pdp/raw_course.py
+++ b/src/student_success_tool/generation/pdp/raw_course.py
@@ -8,7 +8,7 @@ from ...analysis.pdp import utils
 
 class Provider(BaseProvider):
     def raw_course_record(
-        self, cohort_record: t.Optional[dict] = None, normalize_col_names: bool = False, institution_id: int = 12345
+        self, cohort_record: t.Optional[dict] = None, normalize_col_names: bool = False
     ) -> dict[str, object]:
         # use existing values where records overlap
         if cohort_record is not None:
@@ -18,6 +18,7 @@ class Provider(BaseProvider):
             race = cr.get("race", cr["Race"])
             ethnicity = cr.get("ethnicity", cr["Ethnicity"])
             gender = cr.get("gender", cr["Gender"])
+            institution_id = cr.get("institution_id", cr["Institution ID"])
             cohort = cr.get("cohort", cr["Cohort"])
             cohort_term = cr.get("cohort_term", cr["Cohort Term"])
             _has_enrollment_other_inst: bool = (
@@ -33,6 +34,7 @@ class Provider(BaseProvider):
             race = self.race()
             ethnicity = self.ethnicity()
             gender = self.gender()
+            institution_id = self.institution_id()
             cohort = self.cohort()
             cohort_term = self.cohort_term()
             _has_enrollment_other_inst: bool = self.generator.random.random() < 0.25  # type: ignore
@@ -105,6 +107,9 @@ class Provider(BaseProvider):
         return record
 
     def student_guid(self) -> str:
+        return self.numerify("#####!")  # type: ignore
+
+    def institution_id(self) -> str:
         return self.numerify("#####!")  # type: ignore
 
     def student_age(self) -> str:

--- a/tests/generation/pdp/test_raw_cohort.py
+++ b/tests/generation/pdp/test_raw_cohort.py
@@ -24,3 +24,14 @@ def test_raw_cohort_record(min_cohort_yr, max_cohort_yr, normalize_col_names):
         df_obs = pd.DataFrame([obs])
         obs_valid = RawPDPCohortDataSchema.validate(df_obs, lazy=True)
         assert isinstance(obs_valid, pd.DataFrame)  # => data passed validation
+        print(df_obs)
+
+
+def test_multiple_raw_cohort_records():
+    institution_id = 123
+    cohort_records = [
+        FAKER.raw_cohort_record(normalize_col_names=True, institution_id=institution_id) for _ in range(10)
+    ]
+    df_cohort = pd.DataFrame(cohort_records)
+    obs_valid = RawPDPCohortDataSchema.validate(df_cohort, lazy=True)
+    assert isinstance(obs_valid, pd.DataFrame)  # => data passed validation

--- a/tests/generation/pdp/test_raw_cohort.py
+++ b/tests/generation/pdp/test_raw_cohort.py
@@ -30,7 +30,8 @@ def test_raw_cohort_record(min_cohort_yr, max_cohort_yr, normalize_col_names):
 def test_multiple_raw_cohort_records():
     institution_id = 123
     cohort_records = [
-        FAKER.raw_cohort_record(normalize_col_names=True, institution_id=institution_id) for _ in range(10)
+        FAKER.raw_cohort_record(normalize_col_names=True, institution_id=institution_id)
+        for _ in range(10)
     ]
     df_cohort = pd.DataFrame(cohort_records)
     obs_valid = RawPDPCohortDataSchema.validate(df_cohort, lazy=True)

--- a/tests/generation/pdp/test_raw_course.py
+++ b/tests/generation/pdp/test_raw_course.py
@@ -13,10 +13,20 @@ FAKER.add_provider(raw_course.Provider)
     ["normalize_col_names"],
     [(False,), (True,)],
 )
-def test_raw_cohort_record(normalize_col_names):
+def test_raw_course_record(normalize_col_names):
     obs = FAKER.raw_course_record(normalize_col_names=normalize_col_names)
     assert obs and isinstance(obs, dict)
     if normalize_col_names is True:
         df_obs = pd.DataFrame([obs])
         obs_valid = RawPDPCourseDataSchema.validate(df_obs, lazy=True)
         assert isinstance(obs_valid, pd.DataFrame)  # => data passed validation
+        
+
+def test_multiple_raw_course_records():
+    institution_id = 123
+    course_records = [
+        FAKER.raw_course_record(normalize_col_names=True, institution_id=institution_id) for _ in range(10)
+    ]
+    df_obs = pd.DataFrame(course_records)
+    obs_valid = RawPDPCourseDataSchema.validate(df_obs, lazy=False)
+    assert isinstance(obs_valid, pd.DataFrame)  # => data passed validation

--- a/tests/generation/pdp/test_raw_course.py
+++ b/tests/generation/pdp/test_raw_course.py
@@ -20,13 +20,3 @@ def test_raw_course_record(normalize_col_names):
         df_obs = pd.DataFrame([obs])
         obs_valid = RawPDPCourseDataSchema.validate(df_obs, lazy=True)
         assert isinstance(obs_valid, pd.DataFrame)  # => data passed validation
-        
-
-def test_multiple_raw_course_records():
-    institution_id = 123
-    course_records = [
-        FAKER.raw_course_record(normalize_col_names=True, institution_id=institution_id) for _ in range(10)
-    ]
-    df_obs = pd.DataFrame(course_records)
-    obs_valid = RawPDPCourseDataSchema.validate(df_obs, lazy=False)
-    assert isinstance(obs_valid, pd.DataFrame)  # => data passed validation


### PR DESCRIPTION
There's a cohort schema check that ensures there's a single institution for all the data, but the pdp generation script creates a new institution id per record (so data created using the script will fail the validation). This creates the institution id once and uses it for both cohort and course data.

## changes
- Generates institution id once in the parent script and then passes it down.
- Adds a test that uses the new field to pass the same value down to multiple cohorts/courses (this would fail without this change) for both cohort (which has the check) and course (which doesn't)
- Ranames test_raw_cohort_record to test_raw_course_record in test_raw_course.py (unrelated, looks like a copy paste error)

## context
- Noticed this while running through the templates using the existing test data in the repo. Some more similar changes to follow.

## questions
- Should the same schema check exist for the course schema?
- Where should I create the asana ticket (that's mentioned in CONTRIBUTING.md)?
