### PR TITLE
Update inference python file to include shap function

### DIFF
--- a/src/student_success_tool/modeling/inference.py
+++ b/src/student_success_tool/modeling/inference.py
@@ -1,9 +1,9 @@
 import typing as t
 from typing import Iterator
+from shap import KernelExplainer
 
 import numpy as np
 import pandas as pd
-from shap import KernelExplainer
 
 def select_top_features_for_display(
     features: pd.DataFrame,
@@ -67,9 +67,13 @@ def select_top_features_for_display(
     return pd.DataFrame(top_features_info)
 
 
-def calculate_shap_values(iterator: Iterator[pd.DataFrame], *, student_id_col: str,
-                model_features: list[str], explainer: KernelExplainer,
-                mode: pd.Series) -> Iterator[pd.DataFrame]:
+def calculate_shap_values(
+    iterator: Iterator[pd.DataFrame], *, 
+    student_id_col: str,
+    model_features: list[str], 
+    explainer: KernelExplainer,
+    mode: pd.Series
+) -> Iterator[pd.DataFrame]:
     """
     SHAP is computationally expensive, so this function enables parallelization,
     by calculating SHAP values over an iterator of DataFrames. Sparks' repartition

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from student_success_tool.modeling.inference import select_top_features_for_display
-
+from student_success_tool.modeling.inference import calculate_shap_values
 
 @pytest.mark.parametrize(
     [
@@ -115,3 +115,91 @@ def test_select_top_features_for_display(
     )
     assert isinstance(obs, pd.DataFrame) and not obs.empty
     assert pd.testing.assert_frame_equal(obs, exp) is None
+
+
+@pytest.fixture
+def sample_data():
+    data = {
+        'student_id': [1, 2, 3],
+        'feature1': [0.1, 0.2, 0.3],
+        'feature2': [0.4, 0.5, 0.6]
+    }
+    return pd.DataFrame(data)
+
+# Create dummy KernelExplainer 
+class SimpleKernelExplainer:
+    def shap_values(self, X):
+        # Simulate SHAP values: For simplicity, we return random numbers
+        return np.random.rand(len(X), len(X.columns)) * 0.1  # Random SHAP values between 0 and 0.1
+
+@pytest.fixture
+def explainer():
+    return SimpleKernelExplainer()
+
+@pytest.mark.parametrize(
+    "input_data, expected_shape",
+    [
+        ({"student_id": [1, 2, 3], "feature1": [0.1, 0.2, 0.3], "feature2": [0.4, 0.5, 0.6]}, (3, 3)),
+        ({"student_id": [1, 2], "feature1": [0.1, 0.2], "feature2": [0.4, 0.5]}, (2, 3))
+    ]
+)
+def test_calculate_shap_values_basic(input_data, expected_shape, explainer):
+    df = pd.DataFrame(input_data)
+    student_id_col = 'student_id'
+    model_features = ['feature1', 'feature2']
+    mode = df.mode().iloc[0] 
+    
+    iterator = iter([df])
+    
+    result = list(calculate_shap_values(iterator, student_id_col=student_id_col, model_features=model_features, explainer=explainer, mode=mode))
+    
+    # Check that the result contains the expected number of rows and columns
+    shap_df = result[0]
+    assert shap_df.shape == expected_shape
+    
+    # Ensure that 'student_id' column is present
+    assert student_id_col in shap_df.columns
+    
+    # Ensure that SHAP values are generated and are numeric
+    assert isinstance(shap_df[model_features].iloc[0, 0], (float, np.float64))
+    assert isinstance(shap_df[model_features].iloc[0, 1], (float, np.float64))
+    
+    # Ensure student IDs are correctly reattached
+    assert shap_df[student_id_col].iloc[0] == 1
+    assert shap_df[student_id_col].iloc[1] == 2
+
+@pytest.mark.parametrize(
+    "batch1_data, batch2_data, expected_shape1, expected_shape2",
+    [
+        ({"student_id": [1, 2, 3], "feature1": [0.1, 0.2, 0.3], "feature2": [0.4, 0.5, 0.6]},
+         {"student_id": [4, 5, 6], "feature1": [0.7, 0.8, 0.9], "feature2": [0.6, 0.7, 0.8]},
+         (3, 3), (3, 3)),
+        ({"student_id": [4, 5, 6], "feature1": [0.1, 0.2, 0.3], "feature2": [0.4, 0.5, 0.6]},
+         {"student_id": [4, 5, 6], "feature1": [0.5, 0.6, 0.7], "feature2": [0.7, 0.8, 0.9]},
+         (3, 3), (3, 3))
+    ]
+)
+def test_calculate_shap_values_multiple_batches(batch1_data, batch2_data, expected_shape1, expected_shape2, explainer):
+    batch1 = pd.DataFrame(batch1_data)
+    batch2 = pd.DataFrame(batch2_data)
+    
+    student_id_col = 'student_id'
+    model_features = ['feature1', 'feature2']
+    mode = batch1.mode().iloc[0] 
+    
+    iterator = iter([batch1, batch2])
+    
+    result = list(calculate_shap_values(iterator, student_id_col=student_id_col, model_features=model_features, explainer=explainer, mode=mode))
+    
+    # Ensure we have two DataFrames 
+    assert len(result) == 2
+    
+    # Check first batch 
+    shap_df1 = result[0]
+    assert shap_df1.shape == expected_shape1
+    
+    # Check second batch
+    shap_df2 = result[1]
+    assert shap_df2.shape == expected_shape2
+
+

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 import pytest
 
 from student_success_tool.modeling.inference import select_top_features_for_display
@@ -161,8 +162,8 @@ def test_calculate_shap_values_basic(input_data, expected_shape, explainer):
     assert student_id_col in shap_df.columns
     
     # Ensure that SHAP values are generated and are numeric
-    assert isinstance(shap_df[model_features].iloc[0, 0], (float, np.float64))
-    assert isinstance(shap_df[model_features].iloc[0, 1], (float, np.float64))
+    assert is_numeric_dtype(shap_df[model_features].iloc[0, 0])
+    assert is_numeric_dtype(shap_df[model_features].iloc[0, 1])
     
     # Ensure student IDs are correctly reattached
     assert shap_df[student_id_col].iloc[0] == 1


### PR DESCRIPTION
SHAP values need parallelization in order to scale for inference. Typically, predictions are generated for hundreds to thousands of students, so it is critical to have this functionality. Spark's repartition does not conserve row order, so the unique identifier needs to be attached every batch.

## changes
- Added "calculate_shap_values" to inference.py. 
- Added respective unit test within tests subdirectory.

## context
- SHAP values are needed for interpretability. Proper scaling is required for inference.

## questions
- No specific questions