### PR TITLE
[pdp] Add prelim template project config file

### DIFF
--- a/notebooks/pdp/config-TEMPLATE.toml
+++ b/notebooks/pdp/config-TEMPLATE.toml
@@ -1,0 +1,22 @@
+institution_name = "SCHOOL_NAME"
+
+[prepare_modeling_dataset]
+min_passing_grade = 1.0
+min_num_credits_full_time = 12.0
+course_level_pattern = '^(?:[A-Z]+)?(?P<course_level>\d)\d{2}-?(?:[A-Z]+)?$'
+# key_course_subject_areas = ["2DIGIT_CIP_CODE"]
+# key_course_ids = ["COURSE_ID"]
+# target_student_criteria = { ATTRIBUTE = "VALUE" }
+
+[train_evaluate_model]
+dataset_table_path = "CATALOG.SCHEMA.TBL_NAME"
+student_id_col = "student_guid"
+target_col = "target"
+split_col = "split"
+sample_weight_col = "sample_weight"
+student_group_cols = ["student_age", "race", "ethnicity", "gender", "first_gen"]
+# exclude_cols = ["COL_NAME"]
+pos_label = true
+# exclude_frameworks = ["lightgbm", "xgboost"]
+primary_metric = "log_loss"
+timeout_minutes = 5

--- a/tests/configs/test_load.py
+++ b/tests/configs/test_load.py
@@ -1,0 +1,27 @@
+import os
+from contextlib import nullcontext as does_not_raise
+
+import pydantic as pyd
+import pytest
+
+from student_success_tool import configs
+
+FIXTURES_PATH = "tests/fixtures"
+
+
+class BadProjectConfig(pyd.BaseModel):
+    is_bad: bool = pyd.Field(...)
+
+
+@pytest.mark.parametrize(
+    ["file_name", "schema", "context"],
+    [
+        ("project_config.toml", configs.PDPProjectConfig, does_not_raise()),
+        ("project_config.toml", BadProjectConfig, pytest.raises(pyd.ValidationError)),
+    ],
+)
+def test_load_config(file_name, schema, context):
+    file_path = os.path.join(FIXTURES_PATH, file_name)
+    with context:
+        result = configs.load_config(file_path, schema=schema)
+        assert isinstance(result, pyd.BaseModel)

--- a/tests/fixtures/project_config.toml
+++ b/tests/fixtures/project_config.toml
@@ -1,0 +1,22 @@
+institution_name = "test_inst"
+
+[prepare_modeling_dataset]
+min_passing_grade = 1.0
+min_num_credits_full_time = 12.0
+course_level_pattern = '^(?:[A-Z]+)?(?P<course_level>\d)\d{2}-?(?:[A-Z]+)?$'
+key_course_subject_areas = ["24"]
+key_course_ids = ["ENGL101"]
+target_student_criteria = { enrollment_type = "FIRST-TIME", cohort_term = "FALL" }
+
+[train_evaluate_model]
+dataset_table_path = "catalog.test_inst_silver.labeled_data"
+student_id_col = "student_guid"
+target_col = "target"
+split_col = "split"
+sample_weight_col = "sample_weight"
+student_group_cols = ["student_age", "race", "ethnicity", "gender", "first_gen"]
+exclude_cols = ["some_col"]
+pos_label = true
+exclude_frameworks = ["lightgbm", "xgboost"]
+primary_metric = "log_loss"
+timeout_minutes = 5


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- Adds a template config file to the notebooks dir, alongside other templates that rely on the config
- Adds a config test fixture file and adds a test for loading that config

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

Flagged in another PR — having a config template helps folks to use the template notebooks

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- Any objections to including the config template inside the notebooks dir? Slightly awkward name-wise, but functionality-wise makes sense. We could consider renaming `notebooks` to something like, oh, `projects` or `templates`, if this really bugs you!
- Is anyone using this project config functionality in their school pipelines yet? (Besides me for USCB.) I'm thinking of changing the schema, but don't want to break anyone's pipelines. If the answer is yes, I'll push the schema change into the version after the next release of this package, nbd.