### PR TITLE
Refactor SHAP inference functionality

### DIFF
--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pandas as pd
-from pandas.api.types import is_numeric_dtype
 import pytest
+from pandas.api.types import is_numeric_dtype
 
-from student_success_tool.modeling.inference import select_top_features_for_display
-from student_success_tool.modeling.inference import calculate_shap_values
+from student_success_tool.modeling.inference import (
+    calculate_shap_values_spark_udf,
+    select_top_features_for_display,
+)
 
 
 @pytest.mark.parametrize(
@@ -160,7 +162,7 @@ def explainer():
         ),
     ],
 )
-def test_calculate_shap_values_basic(input_data, expected_shape, explainer):
+def test_calculate_shap_values_spark_udf_basic(input_data, expected_shape, explainer):
     df = pd.DataFrame(input_data)
     student_id_col = "student_id"
     model_features = ["feature1", "feature2"]
@@ -169,7 +171,7 @@ def test_calculate_shap_values_basic(input_data, expected_shape, explainer):
     iterator = iter([df])
 
     result = list(
-        calculate_shap_values(
+        calculate_shap_values_spark_udf(
             iterator,
             student_id_col=student_id_col,
             model_features=model_features,
@@ -227,7 +229,7 @@ def test_calculate_shap_values_basic(input_data, expected_shape, explainer):
         ),
     ],
 )
-def test_calculate_shap_values_multiple_batches(
+def test_calculate_shap_values_spark_udf_multiple_batches(
     batch1_data, batch2_data, expected_shape1, expected_shape2, explainer
 ):
     batch1 = pd.DataFrame(batch1_data)
@@ -240,7 +242,7 @@ def test_calculate_shap_values_multiple_batches(
     iterator = iter([batch1, batch2])
 
     result = list(
-        calculate_shap_values(
+        calculate_shap_values_spark_udf(
             iterator,
             student_id_col=student_id_col,
             model_features=model_features,

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -6,6 +6,7 @@ import pytest
 from student_success_tool.modeling.inference import select_top_features_for_display
 from student_success_tool.modeling.inference import calculate_shap_values
 
+
 @pytest.mark.parametrize(
     [
         "features",
@@ -121,86 +122,140 @@ def test_select_top_features_for_display(
 @pytest.fixture
 def sample_data():
     data = {
-        'student_id': [1, 2, 3],
-        'feature1': [0.1, 0.2, 0.3],
-        'feature2': [0.4, 0.5, 0.6]
+        "student_id": [1, 2, 3],
+        "feature1": [0.1, 0.2, 0.3],
+        "feature2": [0.4, 0.5, 0.6],
     }
     return pd.DataFrame(data)
 
-# Create dummy KernelExplainer 
+
+# Create dummy KernelExplainer
 class SimpleKernelExplainer:
     def shap_values(self, X):
         # Simulate SHAP values: For simplicity, we return random numbers
-        return np.random.rand(len(X), len(X.columns)) * 0.1  # Random SHAP values between 0 and 0.1
+        return (
+            np.random.rand(len(X), len(X.columns)) * 0.1
+        )  # Random SHAP values between 0 and 0.1
+
 
 @pytest.fixture
 def explainer():
     return SimpleKernelExplainer()
 
+
 @pytest.mark.parametrize(
     "input_data, expected_shape",
     [
-        ({"student_id": [1, 2, 3], "feature1": [0.1, 0.2, 0.3], "feature2": [0.4, 0.5, 0.6]}, (3, 3)),
-        ({"student_id": [1, 2], "feature1": [0.1, 0.2], "feature2": [0.4, 0.5]}, (2, 3))
-    ]
+        (
+            {
+                "student_id": [1, 2, 3],
+                "feature1": [0.1, 0.2, 0.3],
+                "feature2": [0.4, 0.5, 0.6],
+            },
+            (3, 3),
+        ),
+        (
+            {"student_id": [1, 2], "feature1": [0.1, 0.2], "feature2": [0.4, 0.5]},
+            (2, 3),
+        ),
+    ],
 )
 def test_calculate_shap_values_basic(input_data, expected_shape, explainer):
     df = pd.DataFrame(input_data)
-    student_id_col = 'student_id'
-    model_features = ['feature1', 'feature2']
-    mode = df.mode().iloc[0] 
-    
+    student_id_col = "student_id"
+    model_features = ["feature1", "feature2"]
+    mode = df.mode().iloc[0]
+
     iterator = iter([df])
-    
-    result = list(calculate_shap_values(iterator, student_id_col=student_id_col, model_features=model_features, explainer=explainer, mode=mode))
-    
+
+    result = list(
+        calculate_shap_values(
+            iterator,
+            student_id_col=student_id_col,
+            model_features=model_features,
+            explainer=explainer,
+            mode=mode,
+        )
+    )
+
     # Check that the result contains the expected number of rows and columns
     shap_df = result[0]
     assert shap_df.shape == expected_shape
-    
+
     # Ensure that 'student_id' column is present
     assert student_id_col in shap_df.columns
-    
+
     # Ensure that SHAP values are generated and are numeric
     assert is_numeric_dtype(shap_df[model_features].iloc[0, 0])
     assert is_numeric_dtype(shap_df[model_features].iloc[0, 1])
-    
+
     # Ensure student IDs are correctly reattached
     assert shap_df[student_id_col].iloc[0] == 1
     assert shap_df[student_id_col].iloc[1] == 2
 
+
 @pytest.mark.parametrize(
     "batch1_data, batch2_data, expected_shape1, expected_shape2",
     [
-        ({"student_id": [1, 2, 3], "feature1": [0.1, 0.2, 0.3], "feature2": [0.4, 0.5, 0.6]},
-         {"student_id": [4, 5, 6], "feature1": [0.7, 0.8, 0.9], "feature2": [0.6, 0.7, 0.8]},
-         (3, 3), (3, 3)),
-        ({"student_id": [4, 5, 6], "feature1": [0.1, 0.2, 0.3], "feature2": [0.4, 0.5, 0.6]},
-         {"student_id": [4, 5, 6], "feature1": [0.5, 0.6, 0.7], "feature2": [0.7, 0.8, 0.9]},
-         (3, 3), (3, 3))
-    ]
+        (
+            {
+                "student_id": [1, 2, 3],
+                "feature1": [0.1, 0.2, 0.3],
+                "feature2": [0.4, 0.5, 0.6],
+            },
+            {
+                "student_id": [4, 5, 6],
+                "feature1": [0.7, 0.8, 0.9],
+                "feature2": [0.6, 0.7, 0.8],
+            },
+            (3, 3),
+            (3, 3),
+        ),
+        (
+            {
+                "student_id": [4, 5, 6],
+                "feature1": [0.1, 0.2, 0.3],
+                "feature2": [0.4, 0.5, 0.6],
+            },
+            {
+                "student_id": [4, 5, 6],
+                "feature1": [0.5, 0.6, 0.7],
+                "feature2": [0.7, 0.8, 0.9],
+            },
+            (3, 3),
+            (3, 3),
+        ),
+    ],
 )
-def test_calculate_shap_values_multiple_batches(batch1_data, batch2_data, expected_shape1, expected_shape2, explainer):
+def test_calculate_shap_values_multiple_batches(
+    batch1_data, batch2_data, expected_shape1, expected_shape2, explainer
+):
     batch1 = pd.DataFrame(batch1_data)
     batch2 = pd.DataFrame(batch2_data)
-    
-    student_id_col = 'student_id'
-    model_features = ['feature1', 'feature2']
-    mode = batch1.mode().iloc[0] 
-    
+
+    student_id_col = "student_id"
+    model_features = ["feature1", "feature2"]
+    mode = batch1.mode().iloc[0]
+
     iterator = iter([batch1, batch2])
-    
-    result = list(calculate_shap_values(iterator, student_id_col=student_id_col, model_features=model_features, explainer=explainer, mode=mode))
-    
-    # Ensure we have two DataFrames 
+
+    result = list(
+        calculate_shap_values(
+            iterator,
+            student_id_col=student_id_col,
+            model_features=model_features,
+            explainer=explainer,
+            mode=mode,
+        )
+    )
+
+    # Ensure we have two DataFrames
     assert len(result) == 2
-    
-    # Check first batch 
+
+    # Check first batch
     shap_df1 = result[0]
     assert shap_df1.shape == expected_shape1
-    
+
     # Check second batch
     shap_df2 = result[1]
     assert shap_df2.shape == expected_shape2
-
-


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- auto-formats / lints / tidies up inference src and tests modules
- refactors single-batch shap values calculation logic into a separate function, and renames the spark udf that applies that batch func to chunks of a larger dataset
- adds a unit test for the single-batch shap values func

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

Prior art: PR #48 

Btw @vishpillai123 , I had started putting together an inference nb using code in this repo, but was waiting until I could chat with Daniel (Wednesday!) about how this is meant to work in practice, given confusion about the dbutils nb widgets and such.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
