### PR TITLE
[pdp] Tweak project config + template + test case

### DIFF
--- a/notebooks/pdp/config-v2-TEMPLATE.toml
+++ b/notebooks/pdp/config-v2-TEMPLATE.toml
@@ -42,11 +42,11 @@ collinear_threshold = 10.0
 primary_metric = "log_loss"
 timeout_minutes = 10
 
-[trained_model]
+[models.graduation]
 experiment_id = "EXPERIMENT_ID"
 run_id = "RUN_ID"
-# model_type = "sklearn"
-min_prob_pos_label = 0.5
+model_type = "sklearn"
 
 [inference]
 num_top_features = 5
+min_prob_pos_label = 0.5

--- a/src/student_success_tool/configs/schemas/pdp_v2.py
+++ b/src/student_success_tool/configs/schemas/pdp_v2.py
@@ -148,6 +148,7 @@ class ModelingConfig(pyd.BaseModel):
 
 class InferenceConfig(pyd.BaseModel):
     num_top_features: int = pyd.Field(default=5)
+    min_prob_pos_label: t.Optional[float] = 0.5
     # TODO: extend this configuration, maybe?
 
 
@@ -182,11 +183,10 @@ class DatasetConfig(pyd.BaseModel):
     # finalized: t.Optional[DatasetIOConfig] = None
 
 
-class TrainedModelConfig(pyd.BaseModel):
+class ModelConfig(pyd.BaseModel):
     experiment_id: str
     run_id: str
     model_type: t.Optional[t.Literal["sklearn", "xgboost", "lightgbm"]] = None
-    min_prob_pos_label: t.Optional[float] = 0.5
 
     @pyd.computed_field  # type: ignore[misc]
     @property
@@ -212,7 +212,7 @@ class PDPProjectConfigV2(pyd.BaseModel):
         ),
     )
 
-    # shared dataset parameters
+    # shared parameters
     student_id_col: str = "student_guid"
     target_col: str = "target"
     split_col: str = "split"
@@ -227,12 +227,24 @@ class PDPProjectConfigV2(pyd.BaseModel):
     pred_col: str = "pred"
     pred_prob_col: str = "pred_prob"
     pos_label: t.Optional[int | bool | str] = True
-    # other shared parameters
     random_state: t.Optional[int] = None
 
     # key artifacts produced by project pipeline
-    datasets: t.Optional[dict[str, DatasetConfig]] = None
-    trained_model: t.Optional[TrainedModelConfig] = None
+    datasets: t.Optional[dict[str, DatasetConfig]] = pyd.Field(
+        None,
+        description=(
+            "Mapping of dataset name, e.g. 'labeled', to file/table paths for each "
+            "derived form produced by steps in the data transformation pipeline, "
+            "used to load the artifacts from storage"
+        ),
+    )
+    models: t.Optional[dict[str, ModelConfig]] = pyd.Field(
+        None,
+        description=(
+            "Mapping of model name, e.g. 'graduation', to MLFlow metadata used to "
+            "load the trained artifact from storage"
+        ),
+    )
     # key steps in project pipeline
     preprocessing: t.Optional[PreprocessingConfig] = None
     modeling: t.Optional[ModelingConfig] = None

--- a/tests/configs/schemas/test_pdp_v2.py
+++ b/tests/configs/schemas/test_pdp_v2.py
@@ -57,14 +57,14 @@ def template_cfg_str():
     primary_metric = "log_loss"
     timeout_minutes = 10
 
-    [trained_model]
+    [models.graduation]
     experiment_id = "EXPERIMENT_ID"
     run_id = "RUN_ID"
-    # model_type = "sklearn"
-    min_prob_pos_label = 0.5
+    model_type = "sklearn"
 
     [inference]
     num_top_features = 5
+    min_prob_pos_label = 0.5
     """
 
 


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- changes `cfg.trained_model` into more flexible `cfg.models`, to allow for multiple named models trained using a given pipeline
- moves `min_prob_pos_label` from model to inference cfg, since that's _probably_ the only time in the process we'll need it; I'm not 100% sure on this tho, so I may move it back :)
- adds some descriptions to the config

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

Inspired by feedback in PR #56

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
