### PR TITLE
Modify load_feature_tables() function to allow for absolute & relative paths

### DIFF
--- a/src/student_success_tool/modeling/utils.py
+++ b/src/student_success_tool/modeling/utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import pathlib
 import typing as t
 from collections.abc import Sequence

--- a/src/student_success_tool/modeling/utils.py
+++ b/src/student_success_tool/modeling/utils.py
@@ -86,27 +86,29 @@ def compute_sample_weights(
     )
 
 
-def load_features_table(rel_fpath: str) -> dict[str, dict[str, str]]:
+def load_features_table(fpath: str) -> dict[str, dict[str, str]]:
     """
     Load a features table mapping columns to readable names and (optionally) descriptions
-    from a TOML file located at ``rel_fpath`` within this package.
+    from a TOML file located at ``fpath``, which can either refer to a relative path in this
+    package or an absolute path loaded from local disk.
 
     Args:
-        rel_fpath: Path to features table TOML file relative to package root;
-            for example: "assets/pdp/features_table.toml".
-    """
-    try:
-        # If __file__ is defined, we're in a regular script or module
-        pkg_root_dir = next(
-            p
-            for p in pathlib.Path(__file__).parents
-            if p.parts[-1] == "student_success_tool"
-        )
-    except NameError:
-        # If __file__ is not available (i.e. Jupyter notebook), use the current working directory
-        pkg_root_dir = pathlib.Path(os.getcwd())
+        fpath: Path to features table TOML file relative to package root or absolute;
+            for example: "assets/pdp/features_table.toml" or "/path/to/features_table.toml".
 
-    file_path = pkg_root_dir / rel_fpath
+    Returns:
+    """
+    pkg_root_dir = next(
+        p
+        for p in pathlib.Path(__file__).parents
+        if p.parts[-1] == "student_success_tool"
+    )
+
+    file_path = pathlib.Path(fpath) if pathlib.Path(fpath).is_absolute() else pkg_root_dir / fpath
+
+    if not file_path.exists():
+        raise FileNotFoundError(f"The file at '{file_path}' could not be found.")
+
     with file_path.open(mode="rb") as f:
         features_table = tomllib.load(f)
     LOGGER.info("loaded features table from '%s'", file_path)

--- a/src/student_success_tool/modeling/utils.py
+++ b/src/student_success_tool/modeling/utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pathlib
 import typing as t
 from collections.abc import Sequence
@@ -94,11 +95,17 @@ def load_features_table(rel_fpath: str) -> dict[str, dict[str, str]]:
         rel_fpath: Path to features table TOML file relative to package root;
             for example: "assets/pdp/features_table.toml".
     """
-    pkg_root_dir = next(
-        p
-        for p in pathlib.Path(__file__).parents
-        if p.parts[-1] == "student_success_tool"
-    )
+    try:
+        # If __file__ is defined, we're in a regular script or module
+        pkg_root_dir = next(
+            p
+            for p in pathlib.Path(__file__).parents
+            if p.parts[-1] == "student_success_tool"
+        )
+    except NameError:
+        # If __file__ is not available (i.e. Jupyter notebook), use the current working directory
+        pkg_root_dir = pathlib.Path(os.getcwd())
+
     file_path = pkg_root_dir / rel_fpath
     with file_path.open(mode="rb") as f:
         features_table = tomllib.load(f)

--- a/tests/modeling/test_utils.py
+++ b/tests/modeling/test_utils.py
@@ -119,11 +119,6 @@ def test_compute_sample_weights(df, target_col, class_weight, exp):
             None, 
             FileNotFoundError, 
         ),
-        (
-            "",
-            None,
-            FileNotFoundError,  
-        ),
     ]
 )
 def test_load_features_table(tmpdir, toml_content, expected_output, expect_exception):
@@ -131,14 +126,16 @@ def test_load_features_table(tmpdir, toml_content, expected_output, expect_excep
         toml_file = tmpdir.join("features_table.toml")
         toml_file.write(toml_content)
         
-        file_path = str(toml_file)  
+        file_path = str(toml_file) 
     else:
         file_path = "non_existent_path/features_table.toml"
     
-    with expect_exception:
-        if expected_output:
-            features_table = utils.load_features_table(file_path)
-            assert isinstance(features_table, dict)
-            for key, value in expected_output.items():
-                assert key in features_table
-                assert features_table[key] == value
+    if expect_exception is does_not_raise(): 
+        features_table = utils.load_features_table(file_path)
+        assert isinstance(features_table, dict)
+        for key, value in expected_output.items():
+            assert key in features_table
+            assert features_table[key] == value
+    else:
+        with pytest.raises(expect_exception):
+            utils.load_features_table(file_path)

--- a/tests/modeling/test_utils.py
+++ b/tests/modeling/test_utils.py
@@ -112,12 +112,12 @@ def test_compute_sample_weights(df, target_col, class_weight, exp):
             num_courses = { name = "number of courses taken this term"
             """,
             None,  
-            tomllib.TOMLDecodeError, 
+            pytest.raises(tomllib.TOMLDecodeError), 
         ),
         (
             "",
             None, 
-            FileNotFoundError, 
+            pytest.raises(FileNotFoundError), 
         ),
     ]
 )
@@ -132,7 +132,9 @@ def test_load_features_table(tmpdir, toml_content, expected_output, expect_excep
     
     with expect_exception:
         features_table = utils.load_features_table(file_path)
-        assert isinstance(features_table, dict)
-        for key, value in expected_output.items():
-            assert key in features_table
-            assert features_table[key] == value
+        
+        if expect_exception is does_not_raise():
+            assert isinstance(features_table, dict)
+            for key, value in expected_output.items():
+                assert key in features_table
+                assert features_table[key] == value

--- a/tests/modeling/test_utils.py
+++ b/tests/modeling/test_utils.py
@@ -130,12 +130,9 @@ def test_load_features_table(tmpdir, toml_content, expected_output, expect_excep
     else:
         file_path = "non_existent_path/features_table.toml"
     
-    if expect_exception is does_not_raise(): 
+    with expect_exception:
         features_table = utils.load_features_table(file_path)
         assert isinstance(features_table, dict)
         for key, value in expected_output.items():
             assert key in features_table
             assert features_table[key] == value
-    else:
-        with pytest.raises(expect_exception):
-            utils.load_features_table(file_path)

--- a/tests/modeling/test_utils.py
+++ b/tests/modeling/test_utils.py
@@ -1,6 +1,11 @@
 import pandas as pd
 import pytest
 
+try:
+    import tomllib  # noqa
+except ImportError:  # => PY3.10
+    import tomli as tomllib  # noqa
+
 from student_success_tool.modeling import utils
 
 
@@ -130,9 +135,9 @@ def test_load_features_table(tmpdir, toml_content, expected_output, expect_excep
     
     if expect_exception:
         with pytest.raises(expect_exception):
-            load_features_table(file_path)
+            utils.load_features_table(file_path)
     else:
-        features_table = load_features_table(file_path)
+        features_table = utils.load_features_table(file_path)
         assert isinstance(features_table, dict)
         for key, value in expected_output.items():
             assert key in features_table


### PR DESCRIPTION
I was running into issues with using this function and loading a TOML file from my local directory. 

## changes
- Added is_absolute() to resolve whether path is relative or absolute
- If referring to a path defined within module or an absolute path elsewhere, the function will retrieve the table. 


## context
- I ran into an issue using this function for one of my schools (not PDP).

## questions
None