### PR TITLE
[pdp] Refine train+eval model template nb

### DIFF
--- a/src/student_success_tool/configs/schemas/pdp_v2.py
+++ b/src/student_success_tool/configs/schemas/pdp_v2.py
@@ -215,8 +215,8 @@ class PDPProjectConfigV2(pyd.BaseModel):
     # shared parameters
     student_id_col: str = "student_guid"
     target_col: str = "target"
-    split_col: str = "split"
-    sample_weight_col: t.Optional[str] = None
+    split_col: t.Optional[str] = "split"
+    sample_weight_col: t.Optional[str] = "sample_weight"
     student_group_cols: t.Optional[list[str]] = pyd.Field(
         default=["student_age", "race", "ethnicity", "gender", "first_gen"],
         description=(
@@ -252,6 +252,16 @@ class PDPProjectConfigV2(pyd.BaseModel):
 
     # NOTE: this is for *pydantic* model -- not ML model -- configuration
     model_config = pyd.ConfigDict(extra="ignore", strict=True)
+
+    @pyd.computed_field  # type: ignore[misc]
+    @property
+    def non_feature_cols(self) -> list[str]:
+        return (
+            [self.student_id_col, self.target_col]
+            + ([self.split_col] if self.split_col else [])
+            + ([self.sample_weight_col] if self.sample_weight_col else [])
+            + (self.student_group_cols or [])
+        )
 
     @pyd.field_validator("institution_id", mode="after")
     @classmethod

--- a/src/student_success_tool/modeling/training.py
+++ b/src/student_success_tool/modeling/training.py
@@ -68,7 +68,8 @@ def run_automl_classification(
     kwargs.setdefault("timeout_minutes", 5)
     exclude_cols = kwargs.pop("exclude_cols", [])
     assert isinstance(exclude_cols, list)  # type guard
-    if student_id_col is not None:
+    exclude_cols = exclude_cols.copy()
+    if student_id_col is not None and student_id_col not in exclude_cols:
         exclude_cols.append(student_id_col)
 
     # generate a very descriptive experiment name


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- updates pdp model train+evaluate template nb to leverage new project configs
- makes a couple col names in project config optional, with non-null defaults
- fixes a minor bug in automl wrapper function logic

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

trying to standardize the full pipeline, leverage project configs, and make everything work in both training and prediction runs

sibling to PRs #59 and #60 

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- This nb is a little rougher than the preceding two because it hasn't _really_ been tested in actual pipelines yet. Do you see any serious problems or omissions? Happy to make this nb more robust here, at the same time as project config functionality is added in.