### PR TITLE
[pdp] add funcs to read raw datasets from table or file

### DIFF
--- a/src/student_success_tool/analysis/pdp/dataio.py
+++ b/src/student_success_tool/analysis/pdp/dataio.py
@@ -13,6 +13,190 @@ from . import utils
 LOGGER = logging.getLogger(__name__)
 
 
+def read_raw_pdp_course_data(
+    *,
+    table_path: t.Optional[str] = None,
+    file_path: t.Optional[str] = None,
+    schema: t.Optional[pda.DataFrameModel] = None,
+    dttm_format: str = "%Y%m%d",
+    converter_func: t.Optional[t.Callable[[pd.DataFrame], pd.DataFrame]] = None,
+    spark_session: t.Optional[pyspark.sql.SparkSession] = None,
+    **kwargs: object,
+) -> pd.DataFrame:
+    """
+    Read raw PDP course data from table (in Unity Catalog) or file (in CSV format),
+    and parse+validate it via ``schema`` .
+
+    Args:
+        table_path
+        file_path
+        schema: "DataFrameModel", such as those specified in :mod:`schemas` ,
+            used to parse and validate the raw data. If None, parsing/validation
+            is skipped, and the raw data is returned as-is.
+        dttm_format: Datetime format for "Course Begin/End Date" columns.
+        converter_func: If the raw data is incompatible with ``schema`` ,
+            provide a function that takes the raw dataframe as its sole input,
+            performs whatever (minimal) transformations necessary to bring the data
+            into line with ``schema`` , and then returns it. This converted dataset
+            will then be passed into ``schema`` , if specified.
+            NOTE: Allowances for minor differences in the data should be implemented
+            on the school-specific schema class directly. This function is intended
+            to handle bigger problems, such as duplicate ids or borked columns.
+        spark_session: Required if reading data from ``table_path`` , and optional
+            if reading data from ``file_path`` .
+        **kwargs: Additional arguments passed as-is into underlying read func.
+            Note that raw data is always read in as "string" dtype, then coerced
+            into the correct dtypes using ``schema`` .
+
+    See Also:
+        - :func:`read_data_from_csv_file()`
+        - :func:`read_data_from_delta_table()`
+
+    References:
+        - https://help.studentclearinghouse.org/pdp/knowledge-base/course-level-analysis-ready-file-data-dictionary
+        - https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
+        - https://pandera.readthedocs.io/en/stable/reference/generated/pandera.api.dataframe.model.DataFrameModel.html#pandera.api.dataframe.model.DataFrameModel.validate
+    """
+    if not bool(table_path) ^ bool(file_path):
+        raise ValueError("exactly one of table_path or file_path must be specified")
+    elif table_path is not None and spark_session is None:
+        raise ValueError("spark session must be given when reading data from table")
+
+    df = (
+        read_data_from_csv_file(file_path, spark_session, **kwargs)  # type: ignore
+        if file_path
+        else read_data_from_delta_table(table_path, spark_session)  # type: ignore
+    )
+    df = (
+        # make minimal changes before parsing/validating via schema
+        # standardize column names, for convenience/consistency
+        df.rename(columns=utils.convert_to_snake_case)
+        # basically, any operations needed for dtype coercion to work correctly
+        .assign(
+            # uppercase string values for some cols to avoid case inconsistency later on
+            **{
+                col: ft.partial(_uppercase_string_values, col=col)
+                for col in ("academic_term", "student_age", "race")
+            }
+            # help pandas to parse non-standard datetimes... read_csv() struggles
+            | {
+                col: ft.partial(_parse_dttm_values, col=col, fmt=dttm_format)
+                for col in ("course_begin_date", "course_end_date")
+            }
+        )
+    )
+    return _maybe_convert_maybe_validate_data(df, converter_func, schema)
+
+
+def read_raw_pdp_cohort_data(
+    *,
+    table_path: t.Optional[str] = None,
+    file_path: t.Optional[str] = None,
+    schema: t.Optional[pda.DataFrameModel] = None,
+    converter_func: t.Optional[t.Callable[[pd.DataFrame], pd.DataFrame]] = None,
+    spark_session: t.Optional[pyspark.sql.SparkSession] = None,
+    **kwargs: object,
+) -> pd.DataFrame:
+    """
+    Read raw PDP cohort data from table (in Unity Catalog) or file (in CSV format),
+    and parse+validate it via ``schema`` .
+
+    Args:
+        table_path
+        file_path
+        schema: "DataFrameModel", such as those specified in :mod:`schemas` ,
+            used to parse and validate the raw data. If None, parsing/validation
+            is skipped, and the raw data is returned as-is.
+        converter_func: If the raw data is incompatible with ``schema`` ,
+            provide a function that takes the raw dataframe as its sole input,
+            performs whatever (minimal) transformations necessary to bring the data
+            into line with ``schema`` , and then returns it. This converted dataset
+            will then be passed into ``schema`` , if specified.
+            NOTE: Allowances for minor differences in the data should be implemented
+            on the school-specific schema class directly. This function is intended
+            to handle bigger problems, such as duplicate ids or borked columns.
+        spark_session: Required if reading data from ``table_path`` , and optional
+            if reading data from ``file_path`` .
+        **kwargs: Additional arguments passed as-is into underlying read func.
+            Note that raw data is always read in as "string" dtype, then coerced
+            into the correct dtypes using ``schema`` .
+
+    See Also:
+        - :func:`read_data_from_csv_file()`
+        - :func:`read_data_from_delta_table()`
+
+    References:
+        - https://help.studentclearinghouse.org/pdp/knowledge-base/cohort-level-analysis-ready-file-data-dictionary
+        - https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
+        - https://pandera.readthedocs.io/en/stable/reference/generated/pandera.api.dataframe.model.DataFrameModel.html#pandera.api.dataframe.model.DataFrameModel.validate
+    """
+    if not bool(table_path) ^ bool(file_path):
+        raise ValueError("exactly one of table_path or file_path must be specified")
+    elif table_path is not None and spark_session is None:
+        raise ValueError("spark session must be given when reading data from table")
+
+    df = (
+        read_data_from_csv_file(file_path, spark_session, **kwargs)  # type: ignore
+        if file_path
+        else read_data_from_delta_table(table_path, spark_session)  # type: ignore
+    )
+    df = (
+        # make minimal changes before parsing/validating via schema
+        # standardize column names, for convenience/consistency
+        df.rename(columns=utils.convert_to_snake_case)
+        # basically, any operations needed for dtype coercion to work correctly
+        .assign(
+            # uppercase string values for some cols to avoid case inconsistency later on
+            # for practical reasons, this is the only place where it's easy to do so
+            **{
+                col: ft.partial(_uppercase_string_values, col=col)
+                for col in (
+                    "cohort_term",
+                    "enrollment_type",
+                    "enrollment_intensity_first_term",
+                    "student_age",
+                    "race",
+                    "most_recent_bachelors_at_other_institution_locale",
+                    "most_recent_associates_or_certificate_at_other_institution_locale",
+                    "most_recent_last_enrollment_at_other_institution_locale",
+                    "first_bachelors_at_other_institution_locale",
+                    "first_associates_or_certificate_at_other_institution_locale",
+                )
+            }
+            # replace "UK" with null in GPA cols, so we can coerce to float via schema
+            | {
+                col: ft.partial(_replace_values_with_null, col=col, to_replace="UK")
+                for col in ("gpa_group_term_1", "gpa_group_year_1")
+            }
+            # help pandas to coerce string "1"/"0" values into True/False
+            | {
+                col: ft.partial(_cast_to_bool_via_int, col=col)
+                for col in ("retention", "persistence")
+            }
+        )
+    )
+    return _maybe_convert_maybe_validate_data(df, converter_func, schema)
+
+
+def _maybe_convert_maybe_validate_data(
+    df: pd.DataFrame,
+    converter_func: t.Optional[t.Callable[[pd.DataFrame], pd.DataFrame]] = None,
+    schema: t.Optional[pda.DataFrameModel] = None,
+) -> pd.DataFrame:
+    if converter_func is not None:
+        LOGGER.info("applying %s converter to raw data", converter_func)
+        df = converter_func(df)
+    if schema is None:
+        return df
+    else:
+        try:
+            df = schema.validate(df, lazy=True)  # type: ignore
+            return df  # type: ignore
+        except pandera.errors.SchemaErrors:
+            LOGGER.error("unable to parse/validate raw data")
+            raise
+
+
 def read_raw_pdp_course_data_from_file(
     fpath: str,
     *,
@@ -197,6 +381,33 @@ def _cast_to_bool_via_int(df: pd.DataFrame, *, col: str) -> pd.Series:
         )
         .astype("boolean")
     )
+
+
+def read_data_from_csv_file(
+    file_path: str,
+    spark_session: t.Optional[pyspark.sql.SparkSession] = None,
+    **kwargs: object,
+) -> pd.DataFrame:
+    """
+    Read data from a CSV file at ``file_path`` and return it as a DataFrame.
+
+    Args:
+        file_path: Path to file on disk from which data will be read.
+        spark_session: If given, data is loaded via ``pyspark.sql.DataFrameReader.csv`` ;
+            otherwise, data is loaded via :func:`pandas.read_csv()` .
+        **kwargs: Additional arguments passed as-is into underlying read func.
+
+    See Also:
+        - https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html
+        - https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameReader.csv.html
+    """
+    if spark_session is None:
+        df = pd.read_csv(file_path, dtype="string", **kwargs)  # type: ignore
+    else:
+        df = spark_session.read.csv(file_path, inferSchema=False, **kwargs)  # type: ignore
+    assert isinstance(df, pd.DataFrame)  # type guard
+    LOGGER.info("loaded rows x cols = %s from '%s'", df.shape, file_path)
+    return df
 
 
 def read_data_from_delta_table(

--- a/src/student_success_tool/analysis/pdp/dataio.py
+++ b/src/student_success_tool/analysis/pdp/dataio.py
@@ -402,7 +402,7 @@ def read_data_from_csv_file(
         - https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameReader.csv.html
     """
     if spark_session is None:
-        df = pd.read_csv(file_path, dtype="string", **kwargs)  # type: ignore
+        df = pd.read_csv(file_path, dtype="string", header="infer", **kwargs)  # type: ignore
     else:
         df = spark_session.read.csv(
             file_path,

--- a/src/student_success_tool/analysis/pdp/dataio.py
+++ b/src/student_success_tool/analysis/pdp/dataio.py
@@ -404,7 +404,9 @@ def read_data_from_csv_file(
     if spark_session is None:
         df = pd.read_csv(file_path, dtype="string", **kwargs)  # type: ignore
     else:
-        df = spark_session.read.csv(file_path, inferSchema=False, **kwargs).toPandas()  # type: ignore
+        df = spark_session.read.csv(
+            file_path, inferSchema=False, header=True, **kwargs
+        ).toPandas()  # type: ignore
     assert isinstance(df, pd.DataFrame)  # type guard
     LOGGER.info("loaded rows x cols = %s from '%s'", df.shape, file_path)
     return df

--- a/src/student_success_tool/analysis/pdp/dataio.py
+++ b/src/student_success_tool/analysis/pdp/dataio.py
@@ -405,8 +405,11 @@ def read_data_from_csv_file(
         df = pd.read_csv(file_path, dtype="string", **kwargs)  # type: ignore
     else:
         df = spark_session.read.csv(
-            file_path, inferSchema=False, header=True, **kwargs
-        ).toPandas()  # type: ignore
+            file_path,
+            inferSchema=False,
+            header=True,
+            **kwargs,  # type: ignore
+        ).toPandas()
     assert isinstance(df, pd.DataFrame)  # type guard
     LOGGER.info("loaded rows x cols = %s from '%s'", df.shape, file_path)
     return df

--- a/src/student_success_tool/analysis/pdp/dataio.py
+++ b/src/student_success_tool/analysis/pdp/dataio.py
@@ -404,7 +404,7 @@ def read_data_from_csv_file(
     if spark_session is None:
         df = pd.read_csv(file_path, dtype="string", **kwargs)  # type: ignore
     else:
-        df = spark_session.read.csv(file_path, inferSchema=False, **kwargs)  # type: ignore
+        df = spark_session.read.csv(file_path, inferSchema=False, **kwargs).toPandas()  # type: ignore
     assert isinstance(df, pd.DataFrame)  # type guard
     LOGGER.info("loaded rows x cols = %s from '%s'", df.shape, file_path)
     return df

--- a/tests/analysis/pdp/test_dataio.py
+++ b/tests/analysis/pdp/test_dataio.py
@@ -18,6 +18,53 @@ FIXTURES_PATH = "tests/fixtures"
         ("raw_pdp_course_data.csv", schemas.RawPDPCourseDataSchema, {"nrows": 1}),
     ],
 )
+def test_read_raw_pdp_course_data(file_name, schema, kwargs):
+    file_path = os.path.join(FIXTURES_PATH, file_name)
+    result = dataio.read_raw_pdp_course_data(
+        file_path=file_path, schema=schema, dttm_format="%Y%m%d", **(kwargs or {})
+    )
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
+
+
+@pytest.mark.parametrize(
+    ["file_name", "schema", "converter_func", "exp_ctx"],
+    [
+        (
+            "raw_pdp_course_data_invalid.csv",
+            schemas.RawPDPCourseDataSchema,
+            None,
+            pytest.raises(SchemaErrors),
+        ),
+        (
+            "raw_pdp_course_data_invalid.csv",
+            schemas.RawPDPCourseDataSchema,
+            lambda df: df.drop_duplicates(subset=["institution_id", "student_guid"]),
+            does_not_raise(),
+        ),
+    ],
+)
+def test_read_raw_pdp_course_data_convert(file_name, schema, converter_func, exp_ctx):
+    file_path = os.path.join(FIXTURES_PATH, file_name)
+    with exp_ctx:
+        result = dataio.read_raw_pdp_course_data(
+            file_path=file_path,
+            schema=schema,
+            dttm_format="%Y%m%d",
+            converter_func=converter_func,
+        )
+        assert isinstance(result, pd.DataFrame)
+        assert not result.empty
+
+
+@pytest.mark.parametrize(
+    ["file_name", "schema", "kwargs"],
+    [
+        ("raw_pdp_course_data.csv", None, None),
+        ("raw_pdp_course_data.csv", schemas.RawPDPCourseDataSchema, None),
+        ("raw_pdp_course_data.csv", schemas.RawPDPCourseDataSchema, {"nrows": 1}),
+    ],
+)
 def test_read_raw_pdp_course_data_from_file(file_name, schema, kwargs):
     file_path = os.path.join(FIXTURES_PATH, file_name)
     result = dataio.read_raw_pdp_course_data_from_file(
@@ -57,6 +104,25 @@ def test_read_raw_pdp_course_data_from_file_preprocessing(
         )
         assert isinstance(result, pd.DataFrame)
         assert not result.empty
+
+
+@pytest.mark.parametrize(
+    ["file_name", "schema", "kwargs"],
+    [
+        ("raw_pdp_cohort_data.csv", None, None),
+        ("raw_pdp_cohort_data.csv", schemas.RawPDPCohortDataSchema, None),
+        # Yes and No replace 1 and 0.
+        ("raw_pdp_cohort_data_ys.csv", schemas.RawPDPCohortDataSchema, None),
+        ("raw_pdp_cohort_data.csv", schemas.RawPDPCohortDataSchema, {"nrows": 1}),
+    ],
+)
+def test_read_raw_pdp_cohort_data(file_name, schema, kwargs):
+    file_path = os.path.join(FIXTURES_PATH, file_name)
+    result = dataio.read_raw_pdp_cohort_data(
+        file_path=file_path, schema=schema, **(kwargs or {})
+    )
+    assert isinstance(result, pd.DataFrame)
+    assert not result.empty
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

adds dataio functions to read raw pdp course+cohort datasets from file OR table, as a more general replacement for existing functions that only read these datasets from file

**note:** i'll remove the superseded functions in a later package release, to avoid breaking changes

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

based on plans for running prediction pipelines, it looks like we want to start reading raw datasets from tables rather than files. that's fine! the data _should_ be the same (modulo any weirdness in how things get formatted -- daniel is working on standardizing this afaik). these functions enable that process, while also supporting existing processes.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
