### PR TITLE
Adjust year logic to account for leap days

### DIFF
--- a/src/student_success_tool/generation/pdp/raw_cohort.py
+++ b/src/student_success_tool/generation/pdp/raw_cohort.py
@@ -157,13 +157,17 @@ class Provider(BaseProvider):
     def institution_id(self) -> str:
         return self.numerify("#####!")
 
+    # Returns a string in the format "YYYY-YY" (e.g. "2010-11"), representing a cohort year,
+    # where the first year is the start year (a random date between min_yr and max_yr,
+    # or min_yr and now if the current date if not provided). The second year is the first year + 1.
     def cohort(self, min_yr: int = 2010, max_yr: t.Optional[int] = None) -> str:
         _end_date = date(max_yr, 1, 1) if max_yr is not None else "today"
         start_dt: date = self.generator.date_between(
             start_date=date(min_yr, 1, 1), end_date=_end_date
         )
-        end_dt = start_dt.replace(year=start_dt.year + 1)
-        return f"{start_dt:%Y}-{end_dt:%y}"
+        start_yr = start_dt.year
+        end_yr = f"{start_yr + 1}"[2:]
+        return f"{start_yr}-{end_yr}"
 
     def cohort_term(self) -> str:
         return self.random_element(["FALL", "WINTER", "SPRING", "SUMMER"])


### PR DESCRIPTION
The previous code would occasionally return an error "day is out of range for month" when the randomly selected date was February 29th in a year that has a leap day (like 2024) (as February 29th of the following year would be invalid).