### PR TITLE
[pdp] handle study_id / student_guid cols

### DIFF
--- a/src/student_success_tool/dataio/pdp/raw_data.py
+++ b/src/student_success_tool/dataio/pdp/raw_data.py
@@ -85,6 +85,10 @@ def read_raw_course_data(
             }
         )
     )
+    # HACK!
+    if "study_id" in df.columns:
+        df = df.rename(columns={"study_id": "student_guid"})
+        LOGGER.warning("renaming raw column: 'study_id' => 'student_guid'")
     return _maybe_convert_maybe_validate_data(df, converter_func, schema)
 
 
@@ -175,6 +179,10 @@ def read_raw_cohort_data(
             }
         )
     )
+    # HACK!
+    if "study_id" in df.columns:
+        df = df.rename(columns={"study_id": "student_guid"})
+        LOGGER.warning("renaming raw column: 'study_id' => 'student_guid'")
     return _maybe_convert_maybe_validate_data(df, converter_func, schema)
 
 


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

minimally invasive change: rename `"study_id"` column in raw data to standard `"student_guid"` column during dataio read, so that all downstream code/config works as-is for either case.

alternate possible approach: add a `study_id` field to the raw pdp data schemas, add a check to ensure both student guid and study id aren't present for a given dataframe, and then switch the value of the `student_id_col` field in the project config back and forth, as needed. feels clunky, but on the plus side it doesn't stealthily modify data.

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

for some reason pdp sends a different identifier column for students in different cases; i don't know any details, nobody has explained to me why this is the case. given the lack of understanding, i'm trying to make a minor change that easily lets us run existing pipelines over pdp data, regardless of which identifier column it uses.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

does this change resolve the issue? is it _advisable?_ do you have a preference for some other approach? (note: pandera doesn't support renaming columns e.g. via aliases, so no easy options with the raw data schemas.)