### PR TITLE
[pdp] use new-style shap api

### DIFF
--- a/src/student_success_tool/modeling/inference.py
+++ b/src/student_success_tool/modeling/inference.py
@@ -150,12 +150,12 @@ def calculate_shap_values(
         https://shap.readthedocs.io/en/stable/generated/shap.KernelExplainer.html
     """
     # preserve student ids
-    student_ids = df.loc[:, student_id_col]
+    student_ids = df.loc[:, student_id_col].reset_index(drop=True)
     # impute missing values and run shap values using just features
     features_imp = df.loc[:, feature_names].fillna(fillna_values)
-    shap_values = explainer.shap_values(features_imp)
+    explanation = explainer(features_imp)
     return (
-        pd.DataFrame(data=shap_values, columns=feature_names)
+        pd.DataFrame(data=explanation.values, columns=explanation.feature_names)
         # reattach student ids to their shap values
         .assign(**{student_id_col: student_ids})
     )

--- a/tests/modeling/test_inference.py
+++ b/tests/modeling/test_inference.py
@@ -1,3 +1,5 @@
+import collections
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,6 +13,10 @@ from student_success_tool.modeling.inference import (
 
 
 class DummyKernelExplainer:
+    def __call__(self, X):
+        Explanation = collections.namedtuple("Explanation", ["values", "feature_names"])
+        return Explanation(np.random.rand(len(X), len(X.columns)) * 0.1, X.columns)
+
     def shap_values(self, X):
         # for simplicity, return random numbers of the proper shape
         return np.random.rand(len(X), len(X.columns)) * 0.1


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

uses new "Explanation" API under the hood when calculating SHAP values

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

related: https://github.com/datakind/student-success-tool/pull/96

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- is it possible to return `Explanation` objects instead of constructing DataFrames, such that we could run this in parallel/distributed fashion and then... merge?... the explanations? specifically talking about this mess:

```python
shap_schema = StructType(
    [StructField(cfg.student_id_col, StringType(), nullable=False)]
    + [StructField(col, FloatType(), nullable=False) for col in model_feature_names]
)

df_shap_values = (
    spark.createDataFrame(
        df_test.reindex(columns=model_feature_names + [cfg.student_id_col])
    )  # noqa: F821
    .repartition(sc.defaultParallelism)  # noqa: F821
    .mapInPandas(
        ft.partial(
            modeling.inference.calculate_shap_values_spark_udf,
            student_id_col=cfg.student_id_col,
            model_features=model_feature_names,
            explainer=explainer,
            mode=train_mode,
        ),
        schema=shap_schema,
    )
    .toPandas()
    .set_index(cfg.student_id_col)
    .reindex(df_test[cfg.student_id_col])
    .reset_index(drop=False)
)
```