### PR TITLE
Add approve output pipeline

### DIFF
--- a/pipelines/inference/pdp_inference/workflow_asset_bundle/resources/github_sourced_approval_pipeline
+++ b/pipelines/inference/pdp_inference/workflow_asset_bundle/resources/github_sourced_approval_pipeline
@@ -1,0 +1,73 @@
+resources:
+  jobs:
+    github_sourced_approval_pipeline:
+      name: github_sourced_approval_pipeline
+      description: >-
+        This job should be run by the Datakinder after they have validated the
+        inference output and is ready to publish the output as approved and 
+        notify the user.
+      tasks:
+        - task_key: notify_and_publish_results
+          spark_python_task:
+            python_file: pipelines/tasks/approve_output/approve_output_task.py
+            source: GIT
+            parameters:
+              - --institution_name
+              - "{{job.parameters.institution_name}}"
+              - --sst_job_id
+              - "{{job.parameters.sst_job_id}}"
+              - --db_workspace
+              - "{{job.parameters.db_workspace}}"
+              - --external_bucket_name
+              - "{{job.parameters.external_bucket_name}}"
+              - --email_recipient
+              - "{{job.parameters.email_recipient}}"
+          job_cluster_key: approval-pipeline-cluster
+          libraries:
+            - pypi:
+                package: git+https://github.com/datakind/student-success-tool.git@develop
+      job_clusters:
+        - job_cluster_key: approval-pipeline-cluster
+          new_cluster:
+            cluster_name: ""
+            spark_version: 15.4.x-cpu-ml-scala2.12
+            spark_conf:
+              spark.master: local[*, 4]
+              spark.databricks.cluster.profile: singleNode
+            gcp_attributes:
+              use_preemptible_executors: false
+              google_service_account: ${var.pipeline_sa_email}
+              availability: ON_DEMAND_GCP
+              zone_id: HA
+            node_type_id: n2-standard-8
+            custom_tags:
+              ResourceClass: SingleNode
+              x-databricks-nextgen-cluster: "true"
+            enable_elastic_disk: true
+            data_security_mode: SINGLE_USER
+            runtime_engine: STANDARD
+            num_workers: 0
+      git_source:
+        git_url: https://github.com/datakind/student-success-tool
+        git_provider: gitHub
+        git_branch: develop
+      queue:
+        enabled: true
+      parameters:
+        - name: db_workspace
+          default: dev_sst_02
+        - name: email_recipient
+          default: ${var.end_user_notification_email}
+        - name: external_bucket_name
+          default: dev_6782b2f451f84c17ae6e14e918432b65
+        - name: institution_name
+          default: uni_of_crystal_testing
+        - name: sst_job_id
+          default: "1047723304980128"
+      permissions:
+        - group_name: ${var.fellows_group_to_manage_workflow} 
+          level: CAN_MANAGE
+        - user_name: ${var.service_account_executer}
+          level: CAN_MANAGE_RUN
+        - group_name: ${var.datakind_group_to_manage_workflow} 
+          level: CAN_MANAGE

--- a/pipelines/inference/pdp_inference/workflow_asset_bundle/resources/github_sourced_approval_pipeline
+++ b/pipelines/inference/pdp_inference/workflow_asset_bundle/resources/github_sourced_approval_pipeline
@@ -25,7 +25,7 @@ resources:
           job_cluster_key: approval-pipeline-cluster
           libraries:
             - pypi:
-                package: git+https://github.com/datakind/student-success-tool.git@develop
+                package: git+https://github.com/datakind/student-success-tool.git@e209f19d1e0912739a1de85c704270039e2cb337
       job_clusters:
         - job_cluster_key: approval-pipeline-cluster
           new_cluster:

--- a/pipelines/tasks/approve_output/approve_output_task.py
+++ b/pipelines/tasks/approve_output/approve_output_task.py
@@ -79,7 +79,7 @@ def main():
         APPROVAL_SUBJECT,
         APPROVAL_MESSAGE,
         username,
-        password
+        password,
     )
 
 

--- a/pipelines/tasks/approve_output/approve_output_task.py
+++ b/pipelines/tasks/approve_output/approve_output_task.py
@@ -22,6 +22,7 @@ APPROVAL_MESSAGE = """\
     Your Datakind Student Success Tool inference output has been reviewed by Datakind.
     """
 
+
 def main():
     """Main function."""
     logging.basicConfig(level=logging.INFO)
@@ -60,7 +61,7 @@ def main():
     )
     logging.info("Delete unapproved files for this job from GCP bucket.")
     w = WorkspaceClient()
-    unapproved_path =  f"unapproved/{args.sst_job_id}/"
+    unapproved_path = f"unapproved/{args.sst_job_id}/"
     storage_client = storage.Client()
     bucket = storage_client.bucket(args.external_bucket_name)
     blobs = bucket.list_blobs(prefix=unapproved_path)
@@ -72,10 +73,15 @@ def main():
     password = w.dbutils.secrets.get(scope="sst", key="MANDRILL_PASSWORD")
     logging.info("Sending email notification")
     send_email(
-        sender_email, [args.email_recipient], cc_email_list, APPROVAL_SUBJECT, APPROVAL_MESSAGE, username, password
+        sender_email,
+        [args.email_recipient],
+        cc_email_list,
+        APPROVAL_SUBJECT,
+        APPROVAL_MESSAGE,
+        username,
+        password
     )
 
 
 if __name__ == "__main__":
     main()
-  

--- a/pipelines/tasks/approve_output/approve_output_task.py
+++ b/pipelines/tasks/approve_output/approve_output_task.py
@@ -1,0 +1,81 @@
+"""Task for publishing data that has been approved and deleting the unapproved outputs for that job.
+
+NOTE: this job does NOT move the existing bucket file from unapproved/ to approved/. It instead writes
+the current files in the Databricks volume to approved/ and deletes the unapproved/ output. Which means,
+if the actual file in the Databricks volume gets updated, the webapp will pick up the updates. And the
+old output will be DELETED.
+"""
+
+import argparse
+import logging
+from google.cloud import storage
+
+from student_success_tool.utils.gcs import publish_inference_output_files
+from student_success_tool.utils.emails import send_email
+from databricks.sdk import WorkspaceClient
+from email.headerregistry import Address
+
+APPROVAL_SUBJECT = "Student Success Tool: Inference Output Reviewed By Datakind."
+APPROVAL_MESSAGE = """\
+    Hello!
+
+    Your Datakind Student Success Tool inference output has been reviewed by Datakind.
+    """
+
+def main():
+    """Main function."""
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--db_workspace", required=True, help="Databricks workspace of the task."
+    )
+    parser.add_argument(
+        "--institution_name",
+        required=True,
+        help="IThe Databricks institution name whose output we want to publish",
+    )
+    parser.add_argument(
+        "--external_bucket_name",
+        required=True,
+        help="Name of the bucket we want to publish results to (in format [env]_[inst_id]).",
+    )
+    parser.add_argument(
+        "--sst_job_id",
+        required=True,
+        help="The job run id of the current pipeline execution.",
+    )
+    parser.add_argument(
+        "--email_recipient",
+        required=True,
+        help="User's email who triggered the inference run.",
+    )
+    args = parser.parse_args()
+    logging.info("Publishing files as approved to GCP bucket")
+    publish_inference_output_files(
+        args.db_workspace,
+        args.institution_name,
+        args.external_bucket_name,
+        args.sst_job_id,
+        True,  # Set approved = True since this task runs after human approval.
+    )
+    logging.info("Delete unapproved files for this job from GCP bucket.")
+    w = WorkspaceClient()
+    unapproved_path =  f"unapproved/{args.sst_job_id}/"
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(args.external_bucket_name)
+    blobs = bucket.list_blobs(prefix=unapproved_path)
+    for blob in blobs:
+        blob.delete()
+    username = w.dbutils.secrets.get(scope="sst", key="MANDRILL_USERNAME")
+    sender_email = Address("Datakind Info", "help", "datakind.org")
+    cc_email_list = ["education@datakind.org"]
+    password = w.dbutils.secrets.get(scope="sst", key="MANDRILL_PASSWORD")
+    logging.info("Sending email notification")
+    send_email(
+        sender_email, [args.email_recipient], cc_email_list, APPROVAL_SUBJECT, APPROVAL_MESSAGE, username, password
+    )
+
+
+if __name__ == "__main__":
+    main()
+  


### PR DESCRIPTION
Add a pipeline that approves output (e.g. publishes it to bucket as approved output and notifies user via email)

Add a pipeline (yml file) plus the task that is used in the pipeline to publish a given job's output and notify users via email.