### PR TITLE
[ci] use new chg-file action that's not compromised

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -11,20 +11,14 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      # changed-files action is currently compromised! disabling to avoid security vuln
-      # - name: Get changed files
-      #   id: changed-files
-      #   uses: tj-actions/changed-files@v45
-      #   with:
-      #     files: |
-      #       CHANGELOG.md
-      # - name: Ensure changelog updated
-      #   if: steps.changed-files.outputs.any_changed == 'false'
-      #   run: |
-      #     echo "CHANGELOG.md file must be updated with release notes"
-      #     exit 1
-      # temporarily skipping this check
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@v45.0.1
+        with:
+          files: |
+            CHANGELOG.md
       - name: Ensure changelog updated
+        if: steps.changed-files.outputs.any_changed == 'false'
         run: |
-          echo "CHANGELOG.md file must be updated with release notes!"
-          exit 0
+          echo "CHANGELOG.md file must be updated with release notes"
+          exit 1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -13,25 +13,18 @@ jobs:
         uses: ./.github/actions/setup-python-env
         with:
           python-version: "3.10"
-      # changed-files action is currently compromised! disabling to avoid security vuln
-      # - name: Get changed files
-      #   id: changed-files
-      #   uses: tj-actions/changed-files@v45
-      #   with:
-      #     files: |
-      #       **.py
-      #       **.ipynb
-      # - name: Run linter
-      #   if: steps.changed-files.outputs.any_changed == 'true'
-      #   run: |
-      #     uv tool run ruff check --diff ${{ steps.changed-files.outputs.all_changed_files }}
-      # - name: Run formatter
-      #   if: steps.changed-files.outputs.any_changed == 'true'
-      #   run: |
-      #     uv tool run ruff format --diff ${{ steps.changed-files.outputs.all_changed_files }}
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@v45.0.1
+        with:
+          files: |
+            **.py
+            **.ipynb
       - name: Run linter
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          uv tool run ruff check --diff src/
+          uv tool run ruff check --diff ${{ steps.changed-files.outputs.all_changed_files }}
       - name: Run formatter
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          uv tool run ruff format --diff src/
+          uv tool run ruff format --diff ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -13,17 +13,13 @@ jobs:
         uses: ./.github/actions/setup-python-env
         with:
           python-version: "3.10"
-      # changed-files action is currently compromised! disabling to avoid security vuln
-      # - name: Get changed files
-      #   id: changed-files
-      #   uses: tj-actions/changed-files@v45
-      #   with:
-      #     files: |
-      #       src/**/*.py
-      # - name: Check types
-      #   if: steps.changed-files.outputs.any_changed == 'true'
-      #   run: |
-      #     uv run python -m mypy --install-types --non-interactive ${{ steps.changed-files.outputs.all_changed_files }}
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@v45.0.1
+        with:
+          files: |
+            src/**/*.py
       - name: Check types
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          uv run python -m mypy --install-types --non-interactive src/
+          uv run python -m mypy --install-types --non-interactive ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

replaces old (compromised!) changed-files action with one that is not compromised

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

https://github.com/datakind/student-success-tool/pull/106

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->
