### PR TITLE
trying to add a num_days_since_enrolled feature

### DIFF
--- a/src/student_success_tool/features/pdp/cumulative.py
+++ b/src/student_success_tool/features/pdp/cumulative.py
@@ -273,8 +273,6 @@ def _compute_cumfrac_terms_enrolled(
     return cumfrac_terms_enrolled.astype("Float32")
 
 
-
-
 #######################
 # DEPRECATED / BACKUP #
 # only dig into these if databricks starts freaking out about expanding aggs func above

--- a/src/student_success_tool/features/pdp/cumulative.py
+++ b/src/student_success_tool/features/pdp/cumulative.py
@@ -273,6 +273,8 @@ def _compute_cumfrac_terms_enrolled(
     return cumfrac_terms_enrolled.astype("Float32")
 
 
+
+
 #######################
 # DEPRECATED / BACKUP #
 # only dig into these if databricks starts freaking out about expanding aggs func above

--- a/src/student_success_tool/features/pdp/student_term.py
+++ b/src/student_success_tool/features/pdp/student_term.py
@@ -228,32 +228,32 @@ def year_of_enrollment_at_cohort_inst(
     return pd.Series(np.ceil((dts_diff + 1) / 365.25), dtype="Int8")
 
 
-def num_days_since_first_enrolled(  
-    df: pd.DataFrame,  
-    *,    
-    # using cohort_start_dt 
+def num_days_since_first_enrolled(
+    df: pd.DataFrame,
+    *,
+    # using cohort_start_dt
     cohort_start_dt_col: str = "cohort_start_dt",
-    term_start_dt_col: str = "term_start_dt",  
-    term_end_dt_col: str = "term_end_dt",  
-) -> pd.Series:  
+    term_start_dt_col: str = "term_start_dt",
+    term_end_dt_col: str = "term_end_dt",
+) -> pd.Series:
     return (df[term_end_dt_col] - df[cohort_start_dt_col]).dt.days
 
 
 # some schools have had misaligned cohort start dates and first term dates, which makes me think using term_start_dt might be better- but using cohort_start_dt would be easiest since that's consistent across rows.
 # def num_days_since_first_enrolled(
-#     df: pd.DataFrame, 
+#     df: pd.DataFrame,
 #     *,
-#     student_id_col: str = "student_guid", 
-#     term_start_dt_col: str = "term_start_dt", 
+#     student_id_col: str = "student_guid",
+#     term_start_dt_col: str = "term_start_dt",
 #     term_end_dt_col: str = "term_end_dt",
-# ) -> pd.Series:    
-#     # Group by student id and find the first enrollment date  
-#     first_enrollment_dates = df.groupby(student_id_col)[term_start_dt_col].min()  
-  
-#     # Merge back onto the original dataframe  
-#     df = df.merge(first_enrollment_dates.rename('first_enrollment_date'), left_on=student_id_col, right_index=True)  
-  
-#     # Calculate the number of days since first enrollment  
+# ) -> pd.Series:
+#     # Group by student id and find the first enrollment date
+#     first_enrollment_dates = df.groupby(student_id_col)[term_start_dt_col].min()
+
+#     # Merge back onto the original dataframe
+#     df = df.merge(first_enrollment_dates.rename('first_enrollment_date'), left_on=student_id_col, right_index=True)
+
+#     # Calculate the number of days since first enrollment
 #     num_days_since_first_enrolled = (df[term_end_dt_col] - df['first_enrollment_date']).dt.days
 
 #     return num_days_since_first_enrolled

--- a/src/student_success_tool/features/pdp/student_term.py
+++ b/src/student_success_tool/features/pdp/student_term.py
@@ -239,16 +239,24 @@ def num_days_since_first_enrolled(
     return (df[term_end_dt_col] - df[cohort_start_dt_col]).dt.days
 
 
-# def num_days_since_first_enrolled(  
-#    """ some schools have had misaligned cohort start dates and first term dates, which makes me think using term_start_dt might be better- but using cohort_start_dt would be easiest since that's consistent across rows. IDK if this is correctly grouping by student_guid first """ 
-#     df: pd.DataFrame,  
-#     *,    
-#     term_start_dt_col: str = "term_start_dt",  
-#     term_end_dt_col: str = "term_end_dt",  
-# ) -> pd.Series:  
-#     first_enrollment_date = df[term_start_dt_col].min() 
-#     return (df[term_end_dt_col] - first_enrollment_date).dt.days
-    # not sure if this does it correctly for each student-term, cumulatively 
+# some schools have had misaligned cohort start dates and first term dates, which makes me think using term_start_dt might be better- but using cohort_start_dt would be easiest since that's consistent across rows.
+# def num_days_since_first_enrolled(
+#     df: pd.DataFrame, 
+#     *,
+#     student_id_col: str = "student_guid", 
+#     term_start_dt_col: str = "term_start_dt", 
+#     term_end_dt_col: str = "term_end_dt",
+# ) -> pd.Series:    
+#     # Group by student id and find the first enrollment date  
+#     first_enrollment_dates = df.groupby(student_id_col)[term_start_dt_col].min()  
+  
+#     # Merge back onto the original dataframe  
+#     df = df.merge(first_enrollment_dates.rename('first_enrollment_date'), left_on=student_id_col, right_index=True)  
+  
+#     # Calculate the number of days since first enrollment  
+#     num_days_since_first_enrolled = (df[term_end_dt_col] - df['first_enrollment_date']).dt.days
+
+#     return num_days_since_first_enrolled
 
 
 def student_has_prior_degree(

--- a/src/student_success_tool/features/pdp/term.py
+++ b/src/student_success_tool/features/pdp/term.py
@@ -49,6 +49,12 @@ def add_features(
                 bound="start",
                 first_term_of_year=first_term_of_year,
             ),
+            term_end_dt=ft.partial(
+                shared.year_term_dt,
+                col="term_id",
+                bound="end",
+                first_term_of_year=first_term_of_year,
+            ),
             term_rank=ft.partial(term_rank, year_col=year_col, term_col=term_col),
             term_rank_core=ft.partial(
                 term_rank,

--- a/tests/features/pdp/test_student_term.py
+++ b/tests/features/pdp/test_student_term.py
@@ -416,7 +416,7 @@ def test_student_term_enrollment_intensity(
             "cohort_start_dt",
             "term_start_dt",
             "term_end_dt",
-            pd.Series([273, 486, 1064], dtype="integer"),
+            pd.Series([273, 486, 1064], dtype="int"),
         ),
     ],
 )

--- a/tests/features/pdp/test_student_term.py
+++ b/tests/features/pdp/test_student_term.py
@@ -196,7 +196,7 @@ def test_multicol_grade_aggs_by_group(
 
 
 @pytest.mark.parametrize(
-    ["df", "ccol", "tcol", "exp"], 
+    ["df", "ccol", "tcol", "exp"],
     [
         (
             pd.DataFrame(
@@ -215,7 +215,9 @@ def test_multicol_grade_aggs_by_group(
 )
 def test_year_of_enrollment_at_cohort_inst(df, ccol, tcol, exp):
     obs = student_term.year_of_enrollment_at_cohort_inst(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
+        df,
+        cohort_start_dt_col=ccol,
+        term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -280,7 +282,9 @@ def test_student_has_prior_degree(df, inst, exp):
 )
 def test_term_is_pre_cohort(df, ccol, tcol, exp):
     obs = student_term.term_is_pre_cohort(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
+        df,
+        cohort_start_dt_col=ccol,
+        term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -406,7 +410,7 @@ def test_student_term_enrollment_intensity(
         (
             pd.DataFrame(
                 {
-                    # leaving cohort_start_dt in for now, but we may not need it 
+                    # leaving cohort_start_dt in for now, but we may not need it
                     "cohort_start_dt": ["2019-09-01", "2019-09-01", "2021-02-01"],
                     "term_start_dt": ["2020-02-01", "2020-09-01", "2023-09-01"],
                     "term_end_dt": ["2020-05-31", "2020-12-31", "2023-12-31"],
@@ -422,7 +426,10 @@ def test_student_term_enrollment_intensity(
 )
 def num_days_since_first_enrolled(df, ccol, tscol, tecol, exp):
     obs = student_term.term_is_pre_cohort(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tscol, term_end_dt_col=tecol, 
+        df,
+        cohort_start_dt_col=ccol,
+        term_start_dt_col=tscol,
+        term_end_dt_col=tecol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty

--- a/tests/features/pdp/test_student_term.py
+++ b/tests/features/pdp/test_student_term.py
@@ -196,7 +196,7 @@ def test_multicol_grade_aggs_by_group(
 
 
 @pytest.mark.parametrize(
-    ["df", "ccol", "tcol", "exp"], 
+    ["df", "ccol", "tcol", "exp"],
     [
         (
             pd.DataFrame(
@@ -214,7 +214,9 @@ def test_multicol_grade_aggs_by_group(
 )
 def test_year_of_enrollment_at_cohort_inst(df, ccol, tcol, exp):
     obs = student_term.year_of_enrollment_at_cohort_inst(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
+        df,
+        cohort_start_dt_col=ccol,
+        term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -279,7 +281,9 @@ def test_student_has_prior_degree(df, inst, exp):
 )
 def test_term_is_pre_cohort(df, ccol, tcol, exp):
     obs = student_term.term_is_pre_cohort(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
+        df,
+        cohort_start_dt_col=ccol,
+        term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -405,7 +409,7 @@ def test_student_term_enrollment_intensity(
         (
             pd.DataFrame(
                 {
-                    # leaving cohort_start_dt in for now, but we may not need it 
+                    # leaving cohort_start_dt in for now, but we may not need it
                     "cohort_start_dt": ["2019-09-01", "2019-09-01", "2021-02-01"],
                     "term_start_dt": ["2020-02-01", "2020-09-01", "2023-09-01"],
                     "term_end_dt": ["2020-05-31", "2020-12-31", "2023-12-31"],
@@ -421,7 +425,10 @@ def test_student_term_enrollment_intensity(
 )
 def num_days_since_first_enrolled(df, ccol, tscol, tecol, exp):
     obs = student_term.term_is_pre_cohort(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tscol, term_end_dt_col=tecol, 
+        df,
+        cohort_start_dt_col=ccol,
+        term_start_dt_col=tscol,
+        term_end_dt_col=tecol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty

--- a/tests/features/pdp/test_student_term.py
+++ b/tests/features/pdp/test_student_term.py
@@ -196,7 +196,7 @@ def test_multicol_grade_aggs_by_group(
 
 
 @pytest.mark.parametrize(
-    ["df", "ccol", "tcol", "exp"],
+    ["df", "ccol", "tcol", "exp"], 
     [
         (
             pd.DataFrame(
@@ -208,13 +208,14 @@ def test_multicol_grade_aggs_by_group(
             ),
             "cohort_start_dt",
             "term_start_dt",
+            "term_end_dt",
             pd.Series([1, 2, 3], dtype="Int8"),
         ),
     ],
 )
 def test_year_of_enrollment_at_cohort_inst(df, ccol, tcol, exp):
     obs = student_term.year_of_enrollment_at_cohort_inst(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol
+        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -279,7 +280,7 @@ def test_student_has_prior_degree(df, inst, exp):
 )
 def test_term_is_pre_cohort(df, ccol, tcol, exp):
     obs = student_term.term_is_pre_cohort(
-        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol
+        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -394,6 +395,34 @@ def test_student_term_enrollment_intensity(
         df,
         min_num_credits_full_time=min_num_credits_full_time,
         num_credits_col=num_credits_col,
+    )
+    assert isinstance(obs, pd.Series) and not obs.empty
+    assert obs.equals(exp) or obs.compare(exp).empty
+
+
+@pytest.mark.parametrize(
+    ["df", "ccol", "tscol", "tecol", "exp"],
+    [
+        (
+            pd.DataFrame(
+                {
+                    # leaving cohort_start_dt in for now, but we may not need it 
+                    "cohort_start_dt": ["2019-09-01", "2019-09-01", "2021-02-01"],
+                    "term_start_dt": ["2020-02-01", "2020-09-01", "2023-09-01"],
+                    "term_end_dt": ["2020-05-31", "2020-12-31", "2023-12-31"],
+                },
+                dtype="datetime64[s]",
+            ),
+            "cohort_start_dt",
+            "term_start_dt",
+            "term_end_dt",
+            pd.Series([273, 486, 1064], dtype="boolean"),
+        ),
+    ],
+)
+def num_days_since_first_enrolled(df, ccol, tscol, tecol, exp):
+    obs = student_term.term_is_pre_cohort(
+        df, cohort_start_dt_col=ccol, term_start_dt_col=tscol, term_end_dt_col=tecol, 
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty

--- a/tests/features/pdp/test_student_term.py
+++ b/tests/features/pdp/test_student_term.py
@@ -196,7 +196,7 @@ def test_multicol_grade_aggs_by_group(
 
 
 @pytest.mark.parametrize(
-    ["df", "ccol", "tcol", "exp"],
+    ["df", "ccol", "tcol", "exp"], 
     [
         (
             pd.DataFrame(
@@ -208,16 +208,13 @@ def test_multicol_grade_aggs_by_group(
             ),
             "cohort_start_dt",
             "term_start_dt",
-            "term_end_dt",
             pd.Series([1, 2, 3], dtype="Int8"),
         ),
     ],
 )
 def test_year_of_enrollment_at_cohort_inst(df, ccol, tcol, exp):
     obs = student_term.year_of_enrollment_at_cohort_inst(
-        df,
-        cohort_start_dt_col=ccol,
-        term_start_dt_col=tcol,
+        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -282,9 +279,7 @@ def test_student_has_prior_degree(df, inst, exp):
 )
 def test_term_is_pre_cohort(df, ccol, tcol, exp):
     obs = student_term.term_is_pre_cohort(
-        df,
-        cohort_start_dt_col=ccol,
-        term_start_dt_col=tcol,
+        df, cohort_start_dt_col=ccol, term_start_dt_col=tcol,
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty
@@ -410,7 +405,7 @@ def test_student_term_enrollment_intensity(
         (
             pd.DataFrame(
                 {
-                    # leaving cohort_start_dt in for now, but we may not need it
+                    # leaving cohort_start_dt in for now, but we may not need it 
                     "cohort_start_dt": ["2019-09-01", "2019-09-01", "2021-02-01"],
                     "term_start_dt": ["2020-02-01", "2020-09-01", "2023-09-01"],
                     "term_end_dt": ["2020-05-31", "2020-12-31", "2023-12-31"],
@@ -426,10 +421,7 @@ def test_student_term_enrollment_intensity(
 )
 def num_days_since_first_enrolled(df, ccol, tscol, tecol, exp):
     obs = student_term.term_is_pre_cohort(
-        df,
-        cohort_start_dt_col=ccol,
-        term_start_dt_col=tscol,
-        term_end_dt_col=tecol,
+        df, cohort_start_dt_col=ccol, term_start_dt_col=tscol, term_end_dt_col=tecol, 
     )
     assert isinstance(obs, pd.Series) and not obs.empty
     assert obs.equals(exp) or obs.compare(exp).empty

--- a/tests/features/pdp/test_student_term.py
+++ b/tests/features/pdp/test_student_term.py
@@ -416,7 +416,7 @@ def test_student_term_enrollment_intensity(
             "cohort_start_dt",
             "term_start_dt",
             "term_end_dt",
-            pd.Series([273, 486, 1064], dtype="boolean"),
+            pd.Series([273, 486, 1064], dtype="integer"),
         ),
     ],
 )

--- a/tests/features/pdp/test_term.py
+++ b/tests/features/pdp/test_term.py
@@ -77,6 +77,16 @@ from student_success_tool.features.pdp import term
                             "2023-06-01",
                         ],
                     ),
+                    "term_end_dt": pd.to_datetime(
+                        [
+                            "2020-12-31",
+                            "2020-12-31",
+                            "2021-01-31",
+                            "2021-05-31",
+                            "2019-12-31",
+                            "2023-08-31",
+                        ],
+                    ),
                     "term_rank": [1, 1, 2, 3, 0, 4],
                     "term_rank_core": [1, 1, pd.NA, 2, 0, pd.NA],
                     "term_rank_noncore": [pd.NA, pd.NA, 0, pd.NA, pd.NA, 1],


### PR DESCRIPTION
## changes
Trying to add a `num_days_since_first_enrolled` feature using: (Term End Date - Cohort Begin Date)

## context
- We don't have a `term_end_date` feature, but I made one. 
- Alternatively, could calculate using (Term End Date - min(Term Begin Date))...  but idk how to do the groupby for students first and not calculate it at the student-term level for each row. (I attempted something which I commented out for now if we want to just use the `cohort_start_dt` instead.) 
- Some schools have had misaligned cohort start dates and first term dates, which makes me think using `term_start_dt` might be better- but using `cohort_start_dt` would be easiest since that's consistent across rows.
- I have something commented for potential use with `term_start_dt`

## questions
Any advice/suggestions?
