### PR TITLE
renaming FNPR to FNR for technical accuracy

### DIFF
--- a/src/student_success_tool/modeling/bias_detection.py
+++ b/src/student_success_tool/modeling/bias_detection.py
@@ -17,7 +17,7 @@ LOGGER = logging.getLogger(__name__)
 # Z-score for 95% confidence interval
 Z = st.norm.ppf(1 - (1 - 0.95) / 2)
 
-# Flag FNPR difference thresholds
+# Flag FNR difference thresholds
 HIGH_FLAG_THRESHOLD = 0.15
 MODERATE_FLAG_THRESHOLD = 0.1
 LOW_FLAG_THRESHOLD = 0.05
@@ -52,7 +52,7 @@ def evaluate_bias(
 ) -> None:
     """
     Evaluates the bias in a model's predictions across different student groups for a split
-    denoted by "split_name" across df_pred. For each student group, FNPR (False Negative Positive Rate) is
+    denoted by "split_name" across df_pred. For each student group, FNR (False Negative Rate) is
     computed and any detected biases are flagged. Then, the metrics & plots are logged to MLflow.
 
     Args:
@@ -71,7 +71,7 @@ def evaluate_bias(
 
     for split_name, split_data in df_pred.groupby(split_col):
         for group_col in student_group_cols:
-            group_metrics, fnpr_data = compute_group_bias_metrics(
+            group_metrics, fnr_data = compute_group_bias_metrics(
                 split_data,
                 split_name,
                 group_col,
@@ -84,7 +84,7 @@ def evaluate_bias(
             log_group_metrics_to_mlflow(group_metrics, split_name, group_col)
 
             # Detect bias flags
-            all_flags = flag_bias(fnpr_data)
+            all_flags = flag_bias(fnr_data)
 
             # Filter flags for groups where bias is detected
             group_flags = [
@@ -94,19 +94,19 @@ def evaluate_bias(
             ]
 
             if group_flags:
-                fnpr_fig = plot_fnpr_group(fnpr_data)
+                fnpr_fig = plot_fnr_group(fnr_data)
                 mlflow.log_figure(
-                    fnpr_fig, f"fnpr_plots/{split_name}_{group_col}_fnpr.png"
+                    fnr_fig, f"fnr_plots/{split_name}_{group_col}_fnr.png"
                 )
                 plt.close()
 
                 for flag in group_flags:
                     LOGGER.warning(
-                        " Bias detected for %s on %s - %s, FNPR Difference: %.2f%% (%s) [%s]",
+                        " Bias detected for %s on %s - %s, FNR Difference: %.2f%% (%s) [%s]",
                         flag["group"],
                         flag["split_name"],
                         flag["subgroups"],
-                        flag["fnpr_percentage_difference"] * 100,
+                        flag["fnr_percentage_difference"] * 100,
                         flag["type"],
                         flag["flag"],
                     )
@@ -127,7 +127,7 @@ def compute_group_bias_metrics(
     sample_weight_col: str,
 ) -> tuple[list, list]:
     """
-    Computes group metrics (including FNPR) based on evaluation parameters and logs them to MLflow.
+    Computes group metrics (including FNR) based on evaluation parameters and logs them to MLflow.
 
     Args:
         split_data: Data for the current split to evaluate
@@ -139,23 +139,23 @@ def compute_group_bias_metrics(
         student_group_cols: List of columns for subgroups.
     """
     group_metrics = []
-    fnpr_data = []
+    fnr_data = []
 
     for subgroup_name, subgroup_data in split_data.groupby(group_col):
         labels = subgroup_data[target_col]
         preds = subgroup_data[pred_col]
         pred_probs = subgroup_data[pred_prob_col]
 
-        fnpr, fnpr_lower, fnpr_upper, num_positives = calculate_fnpr_and_ci(
+        fnr, fnr_lower, fnr_upper, num_positives = calculate_fnr_and_ci(
             labels, preds
         )
 
-        fnpr_subgroup_data = {
+        fnr_subgroup_data = {
             "group": group_col,
             "subgroup": subgroup_name,
-            "fnpr": fnpr,
+            "fnr": fnr,
             "split_name": split_name,
-            "ci": (fnpr_lower, fnpr_upper),
+            "ci": (fnr_lower, fnr_upper),
             "size": len(subgroup_data),
             "number_of_positive_samples": num_positives,
         }
@@ -173,38 +173,38 @@ def compute_group_bias_metrics(
         )
         # HACK: avoid duplicative metrics
         eval_metrics.pop("num_positives", None)
-        subgroup_metrics = format_subgroup_metrics(eval_metrics, fnpr_subgroup_data)
+        subgroup_metrics = format_subgroup_metrics(eval_metrics, fnr_subgroup_data)
 
         log_subgroup_metrics_to_mlflow(subgroup_metrics, split_name, group_col)
 
         group_metrics.append(subgroup_metrics)
-        fnpr_data.append(fnpr_subgroup_data)
+        fnr_data.append(fnr_subgroup_data)
 
-    return group_metrics, fnpr_data
+    return group_metrics, fnr_data
 
 
-def format_subgroup_metrics(eval_metrics: dict, fnpr_subgroup_data: dict) -> dict:
+def format_subgroup_metrics(eval_metrics: dict, fnr_subgroup_data: dict) -> dict:
     """
     Formats the evaluation metrics and bias metrics together for logging into MLflow.
 
     Args:
         eval_metrics: Dictionary performance metrics for subgroup
-        fnpr_subgroup_data: List of dictionaries containing FNPR and CI information for each subgroup.
+        fnr_subgroup_data: List of dictionaries containing FNR and CI information for each subgroup.
     Returns:
         Dictionary summarizing both performance & bias metrics
     """
     return {
-        "Subgroup": fnpr_subgroup_data["subgroup"],
+        "Subgroup": fnr_subgroup_data["subgroup"],
         "Number of Samples": eval_metrics["num_samples"],
-        "Number of Positive Samples": fnpr_subgroup_data["number_of_positive_samples"],
+        "Number of Positive Samples": fnr_subgroup_data["number_of_positive_samples"],
         "Actual Target Prevalence": round(eval_metrics["true_positive_prevalence"], 2),
         "Predicted Target Prevalence": round(
             eval_metrics["pred_positive_prevalence"], 2
         ),
         # Bias Metrics
-        "FNPR": round(fnpr_subgroup_data["fnpr"], 2),
-        "FNPR CI Lower": round(fnpr_subgroup_data["ci"][0], 2),
-        "FNPR CI Upper": round(fnpr_subgroup_data["ci"][1], 2),
+        "FNR": round(fnr_subgroup_data["fnr"], 2),
+        "FNR CI Lower": round(fnr_subgroup_data["ci"][0], 2),
+        "FNR CI Upper": round(fnr_subgroup_data["ci"][1], 2),
         # Performance Metrics
         "Accuracy": round(eval_metrics["accuracy"], 2),
         "Precision": round(eval_metrics["precision"], 2),
@@ -215,21 +215,21 @@ def format_subgroup_metrics(eval_metrics: dict, fnpr_subgroup_data: dict) -> dic
 
 
 def flag_bias(
-    fnpr_data: list,
+    fnr_data: list,
     high_bias_thresh: float = HIGH_FLAG_THRESHOLD,
     moderate_bias_thresh: float = MODERATE_FLAG_THRESHOLD,
     low_bias_thresh: float = LOW_FLAG_THRESHOLD,
     min_sample_ratio: float = 0.15,
 ) -> list[dict]:
     """
-    Flags bias based on FNPR differences and confidence interval overlap.
+    Flags bias based on raw FNR differences and confidence interval overlap.
 
     Args:
-        fnpr_data: List of dictionaries containing FNPR and CI information for each subgroup.
+        fnr_data: List of dictionaries containing FNR and CI information for each subgroup.
         high_bias_thresh: Threshold for flagging high bias.
         moderate_bias_thresh: Threshold for flagging moderate bias.
         low_bias_thresh: Threshold for flagging low bias.
-        min_sample_ratio: Percentage of total positive samples required for valid FNPR comparison.
+        min_sample_ratio: Percentage of total positive samples required for valid FNR comparison.
         This gives us flexibility with smaller datasets. We default to 15% since we want to ensure
         we are checking subgroups with sufficient data. When calculating min_samples, we have an upper
         limit of 50 samples so that larger datasets aren't unnecessarily restricted.
@@ -238,7 +238,7 @@ def flag_bias(
         List of dictionaries with bias flag information.
     """
     total_group_positives = sum(
-        subgroup["number_of_positive_samples"] for subgroup in fnpr_data
+        subgroup["number_of_positive_samples"] for subgroup in fnr_data
     )
     min_samples = min(50, int(min_sample_ratio * total_group_positives))
 
@@ -312,44 +312,44 @@ def flag_bias(
     return bias_flags
 
 
-def calculate_fnpr_and_ci(
+def calculate_fnr_and_ci(
     targets: pd.Series,
     preds: pd.Series,
     apply_scaling: bool = True,
 ) -> tuple[float, float, float, bool]:
     """
-    Calculates the False Negative Prediction Rate (FNPR) and its confidence interval, applying Log scaling.
+    Calculates the False Negative Rate (FNR) and its confidence interval, applying Log scaling.
 
     Args:
         targets: "Actual" labels from model output
         preds: Predictions from model output
-        min_fnpr_samples: Minimum number of true positives or false negatives for FNPR calculation.
+        min_fnpr_samples: Minimum number of true positives or false negatives for FNR calculation.
         apply_scaling: Boolean of whether log scaling should be applied. We default to True since we want to
-        sufficiently dampen FNPR variance in low sample sizes situations.
+        sufficiently dampen FNR variance in low sample sizes situations.
 
     Returns:
-        fnpr: False Negative Parity Rate
+        fnr: False Negative Rate
         ci_min: Lower bound of the confidence interval
         ci_max: Upper bound of the confidence interval
-        num_positives: Number of positive samples, for reporting. When the number of positives is low, the FNPR computation may not be reliable.
+        num_positives: Number of positive samples, for reporting. When the number of positives is low, the FNR computation may not be reliable.
     """
     cm = sklearn.metrics.confusion_matrix(targets, preds, labels=[False, True])
     tn, fp, fn, tp = cm.ravel()
 
-    # Calculate FNPR & apply Log Scaling to smoothen FNPR at low sample sizes
+    # Calculate FNR & apply Log Scaling to smoothen FNR at low sample sizes
     num_positives = fn + tp
     if apply_scaling:
         num_positives += np.log1p(num_positives)
 
-    fnpr = fn / num_positives if num_positives > 0 else 0
+    fnr = fn / num_positives if num_positives > 0 else 0
 
     # Confidence Interval Calculation
     margin = (
-        Z * np.sqrt((fnpr * (1 - fnpr)) / num_positives) if num_positives > 0 else 0
+        Z * np.sqrt((fnr * (1 - fnr)) / num_positives) if num_positives > 0 else 0
     )
-    ci_min, ci_max = max(0, fnpr - margin), min(1, fnpr + margin)
+    ci_min, ci_max = max(0, fnr - margin), min(1, fnr + margin)
 
-    return fnpr, ci_min, ci_max, fn + tp
+    return fnr, ci_min, ci_max, fn + tp
 
 
 def check_ci_overlap(
@@ -357,9 +357,9 @@ def check_ci_overlap(
     ci2: tuple[float, float],
 ) -> bool:
     """
-    Checks whether confidence intervals (CIs) overlap. If they do, the FNPR differences
+    Checks whether confidence intervals (CIs) overlap. If they do, the FNR differences
     are within the margin of error at the 95% confidence level. If the CIs do not
-    overlap, this suggests strong statistical evidence that the FNPRs are different.
+    overlap, this suggests strong statistical evidence that the FNRs are different.
 
     Args:
         ci1: Confidence interval (min, max) for subgroup 1
@@ -371,36 +371,36 @@ def check_ci_overlap(
     return not (ci1[1] < ci2[0] or ci2[1] < ci1[0])
 
 
-def z_test_fnpr_difference(
-    fnpr1: float,
-    fnpr2: float,
+def z_test_fnr_difference(
+    fnr1: float,
+    fnr2: float,
     num_positives1: int,
     num_positives2: int,
 ) -> float:
     """
-    Performs a z-test for the FNPR difference between two groups. If there are
+    Performs a z-test for the FNR difference between two groups. If there are
     less than 30 samples of false negatives and true negatives, then we do not
     have enough data to perform a z-test. Thirty samples is the standard check
     for z-tests.
 
     Args:
-        fnpr1: FNPR value for subgroup 1
-        fnpr2: FNPR value for subgroup 2
+        fnr1: FNR value for subgroup 1
+        fnr2: FNR value for subgroup 2
         num_positives1: Number of false negatives + true negatives for subgroup 1
         num_positives2: Number of false negatives + true negatives for subgroup 2
 
     Returns:
-        Two-tailed p-value for the z-test for the FNPR difference between the two subgroups.
+        Two-tailed p-value for the z-test for the raw FNR difference between the two subgroups.
     """
     if (
         num_positives1 <= 30 or num_positives2 <= 30
     ):  # Ensures valid sample sizes for z-test
         return np.nan
     std_error = np.sqrt(
-        ((fnpr1 * (1 - fnpr1)) / num_positives1)
-        + ((fnpr2 * (1 - fnpr2)) / num_positives2)
+        ((fnr1 * (1 - fnr1)) / num_positives1)
+        + ((fnr2 * (1 - fnr2)) / num_positives2)
     )
-    z_stat = (fnpr1 - fnpr2) / std_error
+    z_stat = (fnr1 - fnr2) / std_error
     return float(2 * (1 - st.norm.cdf(abs(z_stat))))  # Two-tailed p-value
 
 
@@ -408,7 +408,7 @@ def generate_bias_flag(
     group: str,
     subgroup1: str,
     subgroup2: str,
-    fnpr_percentage_difference: float,
+    fnr_percentage_difference: float,
     bias_type: str,
     split_name: str,
     flag: str,
@@ -421,11 +421,11 @@ def generate_bias_flag(
         group: Name of the group (e.g. "Gender", "Race", "Age")
         subgroup1: Name of the subgroup 1 (e.g. "Female", "Male", "Asian", "African American", "Caucasian")
         subgroup2: Name of the subgroup 2 (e.g. "Female", "Male", "Asian", "African American", "Caucasian")
-        fnpr_percentage_difference: Absolute value of percentage difference in FNPR
+        fnr_percentage_difference: Absolute value of percentage difference in FNR
         bias_type: Type of bias (e.g. "Non-overlapping CIs", "Overlapping: : p-value: ...")
         split_name: Name of the split (e.g. train/test/validate)
         flag: Flag value (e.g. "🔴 HIGH BIAS", "🟠 MODERATE BIAS", "🟡 LOW BIAS", "🟢 NO BIAS")
-        p_value: p-value for the z-test for the FNPR difference of the subgroup pair
+        p_value: p-value for the z-test for the FNR difference of the subgroup pair
 
     Returns:
         Dictionary containing bias flag information.
@@ -433,7 +433,7 @@ def generate_bias_flag(
     flag_entry = {
         "group": group,
         "subgroups": f"{subgroup1} vs {subgroup2}",
-        "fnpr_percentage_difference": round(fnpr_percentage_difference, 4),
+        "fnr_percentage_difference": round(fnr_percentage_difference, 4),
         "type": (
             bias_type
             if np.isnan(p_value)
@@ -459,7 +459,7 @@ def log_bias_flags_to_mlflow(all_model_flags: list) -> None:
             flag_name = FLAG_NAMES[flag]
             df_flag = (
                 df_model_flags[df_model_flags["flag"] == flag].sort_values(
-                    by="fnpr_percentage_difference", ascending=False
+                    by="fnr_percentage_difference", ascending=False
                 )
                 if df_model_flags.shape[0] > 0
                 else None
@@ -511,29 +511,29 @@ def log_subgroup_metrics_to_mlflow(
             )
 
 
-def plot_fnpr_group(fnpr_data: list) -> matplotlib.figure.Figure:
+def plot_fnr_group(fnr_data: list) -> matplotlib.figure.Figure:
     """
-    Plots False Negative Prediction Rate (FNPR) for a group by subgroup on
+    Plots False Negative Rate (FNR) for a group by subgroup on
     a split (train/test/val) of data with confidence intervals.
 
     Args:
-        fnpr_data: List with dictionaries for each subgroup. Each dictionary
-        comprises of group, fnpr, ci (confidence interval), and split_name keys.
+        fnr_data: List with dictionaries for each subgroup. Each dictionary
+        comprises of group, fnr, ci (confidence interval), and split_name keys.
     """
-    subgroups = [subgroup_data["subgroup"] for subgroup_data in fnpr_data]
-    fnpr = [subgroup_data["fnpr"] for subgroup_data in fnpr_data]
+    subgroups = [subgroup_data["subgroup"] for subgroup_data in fnr_data]
+    fnr = [subgroup_data["fnr"] for subgroup_data in fnr_data]
     min_ci_errors = [
-        subgroup_data["fnpr"] - subgroup_data["ci"][0] for subgroup_data in fnpr_data
+        subgroup_data["fnr"] - subgroup_data["ci"][0] for subgroup_data in fnr_data
     ]
     max_ci_errors = [
-        subgroup_data["ci"][1] - subgroup_data["fnpr"] for subgroup_data in fnpr_data
+        subgroup_data["ci"][1] - subgroup_data["fnr"] for subgroup_data in fnr_data
     ]
 
     y_positions = list(range(len(subgroups)))
     fig, ax = plt.subplots()
 
     for i, (x, y, err_min, err_max) in enumerate(
-        zip(fnpr, y_positions, min_ci_errors, max_ci_errors)
+        zip(fnr, y_positions, min_ci_errors, max_ci_errors)
     ):
         color = PALETTE[i % len(PALETTE)]
         ax.errorbar(
@@ -546,7 +546,7 @@ def plot_fnpr_group(fnpr_data: list) -> matplotlib.figure.Figure:
             markersize=8,
             linewidth=2,
             color=color,
-            label="FNPR" if i == 0 else "",
+            label="FNR" if i == 0 else "",
         )
 
     ax.set(
@@ -554,8 +554,8 @@ def plot_fnpr_group(fnpr_data: list) -> matplotlib.figure.Figure:
         yticklabels=subgroups,
         ylim=(-1, len(subgroups)),
         ylabel="Subgroup",
-        xlabel="False Negative Parity Rate",
-        title=f"""FNPR @ 0.5 for {fnpr_data[0]["group"]} on {fnpr_data[0]["split_name"]}""",
+        xlabel="False Negative Rate",
+        title=f"""FNR @ 0.5 for {fnr_data[0]["group"]} on {fnr_data[0]["split_name"]}""",
     )
     ax.tick_params(axis="both", labelsize=12)
     ax.grid(True, linestyle="--", alpha=0.6)

--- a/src/student_success_tool/modeling/bias_detection.py
+++ b/src/student_success_tool/modeling/bias_detection.py
@@ -52,8 +52,8 @@ def evaluate_bias(
 ) -> None:
     """
     Evaluates the bias in a model's predictions across different student groups for a split
-    denoted by "split_name" across df_pred. For each student group, FNR (False Negative Rate) 
-    Parity is computed using absolute FNR percentage differences and any detected biases are 
+    denoted by "split_name" across df_pred. For each student group, FNR (False Negative Rate)
+    Parity is computed using absolute FNR percentage differences and any detected biases are
     flagged using hypothesis testing. Then, the metrics & plots are logged to MLflow.
 
     Args:
@@ -67,8 +67,8 @@ def evaluate_bias(
         pred_prob_col: Column name for the model's predicted probabilities
         pos_label: Label representing the positive class
         sample_weight_col: Column name representing sample weights for the model.
-    
-    References: 
+
+    References:
         [1] https://fidelity.github.io/jurity/about_fairness.html
         [2] https://docs.oracle.com/en-us/iaas/tools/automlx/latest/legacy/v23.2.3/fairness.html
         [3] https://search.r-project.org/CRAN/refmans/fairness/html/fnr_parity.html
@@ -152,9 +152,7 @@ def compute_group_bias_metrics(
         preds = subgroup_data[pred_col]
         pred_probs = subgroup_data[pred_prob_col]
 
-        fnr, fnr_lower, fnr_upper, num_positives = calculate_fnr_and_ci(
-            labels, preds
-        )
+        fnr, fnr_lower, fnr_upper, num_positives = calculate_fnr_and_ci(labels, preds)
 
         fnr_subgroup_data = {
             "group": group_col,
@@ -228,7 +226,7 @@ def flag_bias(
     min_sample_ratio: float = 0.15,
 ) -> list[dict]:
     """
-    Flags bias based on FNR parity (absolute FNR percentage differences) and confidence interval overlap.
+    Flags bias based on FNR Parity (via absolute FNR percentage differences) and confidence interval overlap.
 
     Args:
         fnr_data: List of dictionaries containing FNR and CI information for each subgroup.
@@ -350,9 +348,7 @@ def calculate_fnr_and_ci(
     fnr = fn / num_positives if num_positives > 0 else 0
 
     # Confidence Interval Calculation
-    margin = (
-        Z * np.sqrt((fnr * (1 - fnr)) / num_positives) if num_positives > 0 else 0
-    )
+    margin = Z * np.sqrt((fnr * (1 - fnr)) / num_positives) if num_positives > 0 else 0
     ci_min, ci_max = max(0, fnr - margin), min(1, fnr + margin)
 
     return fnr, ci_min, ci_max, fn + tp
@@ -403,8 +399,7 @@ def z_test_fnr_difference(
     ):  # Ensures valid sample sizes for z-test
         return np.nan
     std_error = np.sqrt(
-        ((fnr1 * (1 - fnr1)) / num_positives1)
-        + ((fnr2 * (1 - fnr2)) / num_positives2)
+        ((fnr1 * (1 - fnr1)) / num_positives1) + ((fnr2 * (1 - fnr2)) / num_positives2)
     )
     z_stat = (fnr1 - fnr2) / std_error
     return float(2 * (1 - st.norm.cdf(abs(z_stat))))  # Two-tailed p-value

--- a/tests/modeling/test_bias_detection.py
+++ b/tests/modeling/test_bias_detection.py
@@ -40,9 +40,7 @@ def mock_mlflow(monkeypatch):
 @pytest.fixture
 def mock_helpers(monkeypatch):
     monkeypatch.setattr(bias_detection, "flag_bias", lambda fnr_data: fnr_data)
-    monkeypatch.setattr(
-        bias_detection, "plot_fnr_group", lambda fnr_data: plt.figure()
-    )
+    monkeypatch.setattr(bias_detection, "plot_fnr_group", lambda fnr_data: plt.figure())
     monkeypatch.setattr(
         bias_detection,
         "calculate_fnr_and_ci",


### PR DESCRIPTION
## changes
- Changed all naming of FNPR -> FNR.
- Clarified documentation and added references.

## context
- The term FNPR or False Negative Parity Rate (what I've been using) is not commonly used and technically incorrect. We are actually looking at False Negative Rate Parity or FNR Parity, and specifically looking at the absolute percentage differences in FNR. 
- Parity can be either analyzed via a ratio with `FNR_subgroup1 / FNR_subgroup2`, or absolute percentage differences in FNR so `abs(FNR_subgroup1 - FNR_subgroup2)`. 
- This may seem like semantics (and it is), but we want to be accurate when reporting to institutions and in our model cards.
- Another consideration is why don't we look at FNR ratios instead of FNR differences when analyzing parity? 
  - As an example, if we used a ratio and established a threshold of 1.5 (typical standard for flagging), then 30% and 20% or 3% and 2% will both be flagged. 
  - Thus, thresholds with FNR ratios can be less reliable when we have small FNRs. 
  - Honestly, our FNRs can range anywhere from 0 to 50% (maybe even higher), but usually are in the 15% to 40% range. 
  - FNR differences are also more interpretable and we can perform hypothesis testing more easily than with ratios.
- Future work: we will later evaluate our thresholds for FNR differences in May when we do our refactoring. 

## questions
- Does my thought process for this make sense? 
- References:
  - https://docs.oracle.com/en-us/iaas/tools/automlx/latest/legacy/v23.2.3/fairness.html (allows for input of "diff" or "ratio" for parity)
  - https://fidelity.github.io/jurity/about_fairness.html
  - https://afraenkel.github.io/fairness-book/content/05-parity-measures.html#:~:text=A%20false%20positive%20is%20an,graduate%20rate%20of%20admitted%20students.
  - https://search.r-project.org/CRAN/refmans/fairness/html/fnr_parity.html