### PR TITLE
[pdp] more and better structured configs

### DIFF
--- a/pipelines/institution_id/config-TEMPLATE.toml
+++ b/pipelines/institution_id/config-TEMPLATE.toml
@@ -19,7 +19,7 @@ preprocessed = { table_path = "CATALOG.INST_ID_silver.DATASET_NAME_preprocessed"
 # predictions = { table_path = "CATALOG.INST_ID_gold.DATASET_NAME_predictions" }
 finalized = { table_path = "CATALOG.INST_ID_gold.INST_ID_advisor_output_ETC_YYYYMMDD" }
 
-[models.TARGET_CHECKPOINT]
+[model]
 experiment_id = "EXPERIMENT_ID"
 run_id = "RUN_ID"
 framework = "sklearn"
@@ -47,9 +47,11 @@ params = { min_num_credits = 30.0, num_credits_col = "num_credits_earned_cumsum"
 
 [preprocessing.target]
 name = "graduation_150pct_time"
-
-[preprocessing.target.params]
+type_ = "graduation"
 intensity_time_limits = { FULL-TIME = [3.0, "year"], PART-TIME = [6.0, "year"] }
+years_to_degree_col = "first_year_to_associates_at_cohort_inst"
+num_years_in_term = 4
+max_term_rank = "infer"
 
 [modeling.feature_selection]
 incomplete_threshold = 0.5

--- a/src/student_success_tool/configs/pdp.py
+++ b/src/student_success_tool/configs/pdp.py
@@ -52,13 +52,14 @@ class PDPProjectConfig(pyd.BaseModel):
             "used to load the artifacts from storage"
         ),
     )
-    models: dict[str, "ModelConfig"] = pyd.Field(
-        default={},
+    model: t.Optional["ModelConfig"] = pyd.Field(
+        default=None,
         description=(
-            "Mapping of model name, e.g. 'graduation', to MLFlow metadata used to "
-            "load the trained artifact from storage"
+            "Essential metadata for identifying and loading trained model artifacts, "
+            "as produced by the pipeline represented here in this config"
         ),
     )
+
     # key steps in project pipeline
     preprocessing: t.Optional["PreprocessingConfig"] = None
     modeling: t.Optional["ModelingConfig"] = None

--- a/src/student_success_tool/configs/pdp.py
+++ b/src/student_success_tool/configs/pdp.py
@@ -83,7 +83,7 @@ class PDPProjectConfig(pyd.BaseModel):
         return value
 
     # NOTE: this is for *pydantic* model -- not ML model -- configuration
-    model_config = pyd.ConfigDict(extra="ignore", strict=True)
+    model_config = pyd.ConfigDict(extra="forbid", strict=True)
 
 
 class DatasetConfig(pyd.BaseModel):

--- a/src/student_success_tool/configs/pdp.py
+++ b/src/student_success_tool/configs/pdp.py
@@ -8,6 +8,158 @@ from ..preprocessing.features.pdp import constants
 from ..utils import types
 
 
+class PDPProjectConfig(pyd.BaseModel):
+    """Configuration schema for SST PDP projects."""
+
+    institution_id: str = pyd.Field(
+        ...,
+        description=(
+            "Unique (ASCII-only) identifier for institution; used in naming things "
+            "such as source directories, catalog schemas, keys in shared configs, etc."
+        ),
+    )
+    institution_name: str = pyd.Field(
+        ...,
+        description=(
+            "Readable 'display' name for institution, distinct from the 'id'; "
+            "probably just the school's 'official', public name"
+        ),
+    )
+
+    # shared parameters
+    student_id_col: str = "student_id"
+    target_col: str = "target"
+    split_col: t.Optional[str] = "split"
+    sample_weight_col: t.Optional[str] = "sample_weight"
+    student_group_cols: t.Optional[list[str]] = pyd.Field(
+        default=["student_age", "race", "ethnicity", "gender", "first_gen"],
+        description=(
+            "One or more column names in datasets containing student 'groups' "
+            "to use for model bias assessment, but *not* as model features"
+        ),
+    )
+    pred_col: str = "pred"
+    pred_prob_col: str = "pred_prob"
+    pos_label: t.Optional[int | bool | str] = True
+    random_state: t.Optional[int] = None
+
+    # key artifacts produced by project pipeline
+    datasets: dict[str, "DatasetConfig"] = pyd.Field(
+        default={},
+        description=(
+            "Mapping of dataset name, e.g. 'labeled', to file/table paths for each "
+            "derived form produced by steps in the data transformation pipeline, "
+            "used to load the artifacts from storage"
+        ),
+    )
+    models: dict[str, "ModelConfig"] = pyd.Field(
+        default={},
+        description=(
+            "Mapping of model name, e.g. 'graduation', to MLFlow metadata used to "
+            "load the trained artifact from storage"
+        ),
+    )
+    # key steps in project pipeline
+    preprocessing: t.Optional["PreprocessingConfig"] = None
+    modeling: t.Optional["ModelingConfig"] = None
+    inference: t.Optional["InferenceConfig"] = None
+
+    @pyd.computed_field  # type: ignore[misc]
+    @property
+    def non_feature_cols(self) -> list[str]:
+        return (
+            [self.student_id_col, self.target_col]
+            + ([self.split_col] if self.split_col else [])
+            + ([self.sample_weight_col] if self.sample_weight_col else [])
+            + (self.student_group_cols or [])
+        )
+
+    @pyd.field_validator("institution_id", mode="after")
+    @classmethod
+    def check_institution_id_isascii(cls, value: str) -> str:
+        if not re.search(r"^\w+$", value, flags=re.ASCII):
+            raise ValueError(f"institution_id='{value}' is not ASCII-only")
+        return value
+
+    # NOTE: this is for *pydantic* model -- not ML model -- configuration
+    model_config = pyd.ConfigDict(extra="ignore", strict=True)
+
+
+class DatasetConfig(pyd.BaseModel):
+    raw_course: "DatasetIOConfig"
+    raw_cohort: "DatasetIOConfig"
+    preprocessed: t.Optional["DatasetIOConfig"] = None
+    predictions: t.Optional["DatasetIOConfig"] = None
+    finalized: t.Optional["DatasetIOConfig"] = None
+
+
+class DatasetIOConfig(pyd.BaseModel):
+    table_path: t.Optional[str] = pyd.Field(
+        default=None,
+        description=(
+            "Path to a table in Unity Catalog where dataset is stored, "
+            "including the full three-level namespace: 'CATALOG.SCHEMA.TABLE'"
+        ),
+    )
+    file_path: t.Optional[str] = pyd.Field(
+        default=None,
+        description="Full, absolute path to dataset on disk, e.g. a Databricks Volume",
+    )
+    # TODO: if/when we allow different file formats, add this parameter ...
+    # file_format: t.Optional[t.Literal["csv", "parquet"]] = pyd.Field(default=None)
+
+    @pyd.model_validator(mode="after")
+    def check_some_nonnull_inputs(self):
+        if self.table_path is None and self.file_path is None:
+            raise ValueError("table_path and/or file_path must be non-null")
+        return self
+
+
+class ModelConfig(pyd.BaseModel):
+    experiment_id: str
+    run_id: str
+    framework: t.Optional[t.Literal["sklearn", "xgboost", "lightgbm"]] = None
+
+    @pyd.computed_field  # type: ignore[misc]
+    @property
+    def mlflow_model_uri(self) -> str:
+        return f"runs:/{self.run_id}/model"
+
+
+class PreprocessingConfig(pyd.BaseModel):
+    features: "FeaturesConfig"
+    selection: "SelectionConfig"
+    checkpoint: "CheckpointConfig"
+    target: "TargetConfig"
+    splits: dict[t.Literal["train", "test", "validate"], float] = pyd.Field(
+        default={"train": 0.6, "test": 0.2, "validate": 0.2},
+        description=(
+            "Mapping of name to fraction of the full datset belonging to a given 'split', "
+            "which is a randomized subset used for different parts of the modeling process"
+        ),
+    )
+    sample_class_weight: t.Optional[t.Literal["balanced"] | dict[object, int]] = (
+        pyd.Field(
+            default=None,
+            description=(
+                "Weights associated with classes in the form ``{class_label: weight}`` "
+                "or 'balanced' to automatically adjust weights inversely proportional "
+                "to class frequencies in the input data. "
+                "If null (default), then sample weights are not computed."
+            ),
+        )
+    )
+
+    @pyd.field_validator("splits", mode="after")
+    @classmethod
+    def check_split_fractions(cls, value: dict) -> dict:
+        if (sum_fracs := sum(value.values())) != 1.0:
+            raise pyd.ValidationError(
+                f"split fractions must sum up to 1.0, but input sums up to {sum_fracs}"
+            )
+        return value
+
+
 class FeaturesConfig(pyd.BaseModel):
     min_passing_grade: float = pyd.Field(
         default=constants.DEFAULT_MIN_PASSING_GRADE,
@@ -98,38 +250,10 @@ class TargetConfig(pyd.BaseModel):
     params: dict[str, object] = pyd.Field(default_factory=dict)
 
 
-class PreprocessingConfig(pyd.BaseModel):
-    features: FeaturesConfig
-    selection: SelectionConfig
-    checkpoint: CheckpointConfig
-    target: TargetConfig
-    splits: dict[t.Literal["train", "test", "validate"], float] = pyd.Field(
-        default={"train": 0.6, "test": 0.2, "validate": 0.2},
-        description=(
-            "Mapping of name to fraction of the full datset belonging to a given 'split', "
-            "which is a randomized subset used for different parts of the modeling process"
-        ),
-    )
-    sample_class_weight: t.Optional[t.Literal["balanced"] | dict[object, int]] = (
-        pyd.Field(
-            default=None,
-            description=(
-                "Weights associated with classes in the form ``{class_label: weight}`` "
-                "or 'balanced' to automatically adjust weights inversely proportional "
-                "to class frequencies in the input data. "
-                "If null (default), then sample weights are not computed."
-            ),
-        )
-    )
-
-    @pyd.field_validator("splits", mode="after")
-    @classmethod
-    def check_split_fractions(cls, value: dict) -> dict:
-        if (sum_fracs := sum(value.values())) != 1.0:
-            raise pyd.ValidationError(
-                f"split fractions must sum up to 1.0, but input sums up to {sum_fracs}"
-            )
-        return value
+class ModelingConfig(pyd.BaseModel):
+    feature_selection: t.Optional["FeatureSelectionConfig"] = None
+    training: "TrainingConfig"
+    evaluation: t.Optional["EvaluationConfig"] = None
 
 
 class FeatureSelectionConfig(pyd.BaseModel):
@@ -183,131 +307,7 @@ class EvaluationConfig(pyd.BaseModel):
     )
 
 
-class ModelingConfig(pyd.BaseModel):
-    feature_selection: t.Optional[FeatureSelectionConfig] = None
-    training: TrainingConfig
-    evaluation: t.Optional[EvaluationConfig] = None
-
-
 class InferenceConfig(pyd.BaseModel):
     num_top_features: int = pyd.Field(default=5)
     min_prob_pos_label: t.Optional[float] = 0.5
     # TODO: extend this configuration, maybe?
-
-
-class DatasetIOConfig(pyd.BaseModel):
-    table_path: t.Optional[str] = pyd.Field(
-        default=None,
-        description=(
-            "Path to a table in Unity Catalog where dataset is stored, "
-            "including the full three-level namespace: 'CATALOG.SCHEMA.TABLE'"
-        ),
-    )
-    file_path: t.Optional[str] = pyd.Field(
-        default=None,
-        description="Full, absolute path to dataset on disk, e.g. a Databricks Volume",
-    )
-    # TODO: if/when we allow different file formats, add this parameter ...
-    # file_format: t.Optional[t.Literal["csv", "parquet"]] = pyd.Field(default=None)
-
-    @pyd.model_validator(mode="after")
-    def check_some_nonnull_inputs(self):
-        if self.table_path is None and self.file_path is None:
-            raise ValueError("table_path and/or file_path must be non-null")
-        return self
-
-
-class DatasetConfig(pyd.BaseModel):
-    raw_course: DatasetIOConfig
-    raw_cohort: DatasetIOConfig
-    preprocessed: t.Optional[DatasetIOConfig] = None
-    predictions: t.Optional[DatasetIOConfig] = None
-    finalized: t.Optional[DatasetIOConfig] = None
-
-
-class ModelConfig(pyd.BaseModel):
-    experiment_id: str
-    run_id: str
-    framework: t.Optional[t.Literal["sklearn", "xgboost", "lightgbm"]] = None
-
-    @pyd.computed_field  # type: ignore[misc]
-    @property
-    def mlflow_model_uri(self) -> str:
-        return f"runs:/{self.run_id}/model"
-
-
-class PDPProjectConfig(pyd.BaseModel):
-    """Configuration schema for SST PDP projects."""
-
-    institution_id: str = pyd.Field(
-        ...,
-        description=(
-            "Unique (ASCII-only) identifier for institution; used in naming things "
-            "such as source directories, catalog schemas, keys in shared configs, etc."
-        ),
-    )
-    institution_name: str = pyd.Field(
-        ...,
-        description=(
-            "Readable 'display' name for institution, distinct from the 'id'; "
-            "probably just the school's 'official', public name"
-        ),
-    )
-
-    # shared parameters
-    student_id_col: str = "student_id"
-    target_col: str = "target"
-    split_col: t.Optional[str] = "split"
-    sample_weight_col: t.Optional[str] = "sample_weight"
-    student_group_cols: t.Optional[list[str]] = pyd.Field(
-        default=["student_age", "race", "ethnicity", "gender", "first_gen"],
-        description=(
-            "One or more column names in datasets containing student 'groups' "
-            "to use for model bias assessment, but *not* as model features"
-        ),
-    )
-    pred_col: str = "pred"
-    pred_prob_col: str = "pred_prob"
-    pos_label: t.Optional[int | bool | str] = True
-    random_state: t.Optional[int] = None
-
-    # key artifacts produced by project pipeline
-    datasets: dict[str, DatasetConfig] = pyd.Field(
-        default={},
-        description=(
-            "Mapping of dataset name, e.g. 'labeled', to file/table paths for each "
-            "derived form produced by steps in the data transformation pipeline, "
-            "used to load the artifacts from storage"
-        ),
-    )
-    models: dict[str, ModelConfig] = pyd.Field(
-        default={},
-        description=(
-            "Mapping of model name, e.g. 'graduation', to MLFlow metadata used to "
-            "load the trained artifact from storage"
-        ),
-    )
-    # key steps in project pipeline
-    preprocessing: t.Optional[PreprocessingConfig] = None
-    modeling: t.Optional[ModelingConfig] = None
-    inference: t.Optional[InferenceConfig] = None
-
-    @pyd.computed_field  # type: ignore[misc]
-    @property
-    def non_feature_cols(self) -> list[str]:
-        return (
-            [self.student_id_col, self.target_col]
-            + ([self.split_col] if self.split_col else [])
-            + ([self.sample_weight_col] if self.sample_weight_col else [])
-            + (self.student_group_cols or [])
-        )
-
-    @pyd.field_validator("institution_id", mode="after")
-    @classmethod
-    def check_institution_id_isascii(cls, value: str) -> str:
-        if not re.search(r"^\w+$", value, flags=re.ASCII):
-            raise ValueError(f"institution_id='{value}' is not ASCII-only")
-        return value
-
-    # NOTE: this is for *pydantic* model -- not ML model -- configuration
-    model_config = pyd.ConfigDict(extra="ignore", strict=True)

--- a/src/student_success_tool/configs/pdp.py
+++ b/src/student_success_tool/configs/pdp.py
@@ -131,7 +131,7 @@ class PreprocessingConfig(pyd.BaseModel):
     features: "FeaturesConfig"
     selection: "SelectionConfig"
     checkpoint: "CheckpointConfig"
-    target: "TargetConfig"
+    target: "TargetGraduationConfig | TargetRetentionConfig | TargetCreditsEarnedConfig"
     splits: dict[t.Literal["train", "test", "validate"], float] = pyd.Field(
         default={"train": 0.6, "test": 0.2, "validate": 0.2},
         description=(
@@ -246,9 +246,33 @@ class CheckpointConfig(pyd.BaseModel):
     params: dict[str, object] = pyd.Field(default_factory=dict)
 
 
-class TargetConfig(pyd.BaseModel):
-    name: str = pyd.Field(default="target")
-    params: dict[str, object] = pyd.Field(default_factory=dict)
+class TargetBaseConfig(pyd.BaseModel):
+    name: str = pyd.Field(
+        default=...,
+        description="Descriptive name for target, used as a component in model name",
+    )
+    type_: t.Literal["graduation", "retention", "credits_earned"] = pyd.Field(
+        default=..., description="Type of target to which config is applied"
+    )
+
+
+class TargetGraduationConfig(TargetBaseConfig):
+    intensity_time_limits: types.IntensityTimeLimitsType
+    years_to_degree_col: str
+    num_terms_in_year: int = pyd.Field(default=4)
+    max_term_rank: int | t.Literal["infer"]
+
+
+class TargetRetentionConfig(TargetBaseConfig):
+    max_academic_year: str | t.Literal["infer"]
+
+
+class TargetCreditsEarnedConfig(TargetBaseConfig):
+    min_num_credits: float
+    # TODO: is there any way to represent checkpoint arg in toml, given its dtype?
+    intensity_time_limits: types.IntensityTimeLimitsType
+    num_terms_in_year: int = pyd.Field(default=4)
+    max_term_rank: int | t.Literal["infer"]
 
 
 class ModelingConfig(pyd.BaseModel):

--- a/tests/configs/test_pdp.py
+++ b/tests/configs/test_pdp.py
@@ -31,6 +31,11 @@ def template_cfg_str():
     raw_cohort = { file_path = "/Volumes/CATALOG/INST_NAME_bronze/INST_NAME_bronze_file_volume/FILE_NAME_COHORT.csv" }
     preprocessed = { table_path = "CATALOG.SCHEMA.TABLE_NAME" }
 
+    [model]
+    experiment_id = "EXPERIMENT_ID"
+    run_id = "RUN_ID"
+    framework = "sklearn"
+
     [preprocessing]
     splits = { train = 0.6, test = 0.2, validate = 0.2 }
     sample_class_weight = "balanced"
@@ -49,7 +54,9 @@ def template_cfg_str():
     [preprocessing.checkpoint]
 
     [preprocessing.target]
-    params = { min_num_credits_checkin = 30.0, min_num_credits_target = 60.0 }
+    name = "my_great_retention_target"
+    type_ = "retention"
+    max_academic_year = "infer"
 
     [modeling.feature_selection]
     incomplete_threshold = 0.5
@@ -60,11 +67,6 @@ def template_cfg_str():
     # exclude_frameworks = ["xgboost", "lightgbm"]
     primary_metric = "log_loss"
     timeout_minutes = 10
-
-    [models.graduation]
-    experiment_id = "EXPERIMENT_ID"
-    run_id = "RUN_ID"
-    framework = "sklearn"
 
     [inference]
     num_top_features = 5
@@ -96,9 +98,18 @@ def test_template_pdp_cfgs(template_cfg_str):
             """
             institution_id = "inst_id"
             institution_name = "Inst Name"
-
             [datasets.labeled]
             foo = { "table_path" = "CATALOG.SCHEMA.TABLE_NAME" }
+            """,
+            pytest.raises(pyd.ValidationError),
+        ),
+        (
+            """
+            institution_id = "inst_id"
+            institution_name = "Inst Name"
+
+            [models.foo]
+            experiment_id = "EXPERIMENT_ID"
             """,
             pytest.raises(pyd.ValidationError),
         ),


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- reorders project config file so that classes follow in definition order
- restricts project config to defining a single ("best") model, rather than a mapping of models
- adds separate, fully-specified configs for each target, rather than a generic under-specified target config; also requires a new `type_` field, for model card parsing logic
- forbids extra params in project configs, just to be safe
- updates template config and tests

**TODO:** add checkpoint-specific configs in the same manner as targets

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

alternative to a subset of changes in PR #151

note: model configs are based on what's implemented in PR #149

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- can this configuration be used to both populate model cards and execute pipelines without duplicate info, and still in a human-friendly form?