### PR TITLE
refactoring PDP templates to v0.3.1

### DIFF
--- a/pipelines/institution_id/00-data-assessment-TEMPLATE.py
+++ b/pipelines/institution_id/00-data-assessment-TEMPLATE.py
@@ -25,7 +25,7 @@
 
 # install dependencies, of which most/all should come through our 1st-party SST package
 
-# %pip install "student-success-tool == 0.2.0"
+# %pip install "student-success-tool == 0.3.0"
 
 # COMMAND ----------
 
@@ -92,18 +92,13 @@ cfg
 
 # COMMAND ----------
 
-# TODO: if dataset info included in cfg, specify its name here
-dataset_name = "DATASET_NAME"
-
 # MAGIC %md
 # MAGIC ## course dataset
 
 # COMMAND ----------
 
-# TODO: fill in the actual path to school's raw course file
-# okay to add it to project config now or later, whatever you prefer
-raw_course_file_path = cfg.datasets[dataset_name].raw_course.file_path
-# raw_course_file_path = "/Volumes/CATALOG/INST_ID_bronze/INST_ID_bronze_file_volume/SCHOOL_COURSE_AR_DEID_DTTM.csv"
+# add actual path to school's raw course file into the project config
+raw_course_file_path = cfg.datasets.bronze.raw_course.file_path
 
 # COMMAND ----------
 

--- a/pipelines/institution_id/00-data-assessment-TEMPLATE.py
+++ b/pipelines/institution_id/00-data-assessment-TEMPLATE.py
@@ -25,7 +25,7 @@
 
 # install dependencies, of which most/all should come through our 1st-party SST package
 
-# %pip install "student-success-tool == 0.3.0"
+# %pip install "student-success-tool == 0.3.1"
 
 # COMMAND ----------
 
@@ -79,9 +79,6 @@ from pipelines import *  # noqa: F403
 # COMMAND ----------
 
 # project configuration should be stored in a config file in TOML format
-# it'll start out with just basic info: institution_id, institution_name
-# but as each step of the pipeline gets built, more parameters will be moved
-# from hard-coded notebook variables to shareable, persistent config fields
 cfg = dataio.read_config("./config-TEMPLATE.toml", schema=configs.pdp.PDPProjectConfig)
 cfg
 
@@ -201,10 +198,8 @@ df_course
 
 # COMMAND ----------
 
-# TODO: fill in the actual path to school's raw cohort file
-# okay to add it to project config now or later, whatever you prefer
-raw_cohort_file_path = cfg.datasets[dataset_name].raw_cohort.file_path
-# raw_cohort_file_path = "/Volumes/CATALOG/INST_ID_bronze/INST_ID_bronze_file_volume/SCHOOL_COHORT_AR_DEID_DTTM.csv"
+# add actual path to school's raw cohort file into the project config
+raw_cohort_file_path = cfg.datasets.bronze.raw_cohort.file_path
 
 # COMMAND ----------
 
@@ -245,57 +240,13 @@ df_cohort
 # MAGIC Before continuing on to EDA, now's a great time to do a couple things:
 # MAGIC
 # MAGIC - Copy any school-specific raw dataset schemas into a `schemas.py` file in the current working directory
-# MAGIC - Copy any school-specific preprocessing functions needed to coerce the raw data into a standardized form into a `dataio.py` file in the current working directory
-# MAGIC - **Optional:** If you want easy access to outputs from every (sub-)step of the data transformation pipeline, save the validated datasets into this school's "silver" schema in Unity Catalog.
-
-# COMMAND ----------
-
-dataio.write.to_delta_table(
-    df_course,
-    "CATALOG.INST_NAME_silver.course_dataset_validated",
-    spark_session=spark,
-)
-
-# COMMAND ----------
-
-dataio.write.to_delta_table(
-    df_cohort,
-    "CATALOG.INST_NAME_silver.cohort_dataset_validated",
-    spark_session=spark,
-)
+# MAGIC - Copy any school-specific converter functions needed to coerce the raw data into a standardized form into a `dataio.py` file in the current working directory
+# MAGIC - You can then reload the raw files using the necessary custom converter functions & schemas and then proceed with EDA below.
 
 # COMMAND ----------
 
 # MAGIC %md
 # MAGIC # exploratory data analysis
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## read validated data
-# MAGIC
-# MAGIC (optional, so you don't have to execute the validation process more than once)
-
-# COMMAND ----------
-
-# use base or school-specific schema, as needed
-df_course = schemas.pdp.RawPDPCourseDataSchema(
-    dataio.read.from_delta_table(
-        "CATALOG.INST_NAME_silver.course_dataset_validated",
-        spark_session=spark,
-    )
-)
-df_course.shape
-
-# COMMAND ----------
-
-df_cohort = schemas.pdp.RawPDPCohortDataSchema(
-    dataio.read.from_delta_table(
-        "CATALOG.INST_NAME_silver.cohort_dataset_validated",
-        spark_session=spark,
-    )
-)
-df_cohort.shape
 
 # COMMAND ----------
 

--- a/pipelines/institution_id/00-data-assessment-TEMPLATE.py
+++ b/pipelines/institution_id/00-data-assessment-TEMPLATE.py
@@ -177,7 +177,7 @@ df_course
 # MAGIC ```python
 # MAGIC import functools as ft
 # MAGIC
-# MAGIC df_course = pdp.dataio.read_raw_pdp_course_data_from_file(
+# MAGIC df_course = dataio.pdp.read_raw_course_data(
 # MAGIC     fpath_course,
 # MAGIC     schema=RawSCHOOLCourseDataSchema,
 # MAGIC     dttm_format="%Y%m%d.0",

--- a/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
+++ b/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
@@ -41,7 +41,7 @@ import pandas as pd  # noqa: F401
 import seaborn as sb
 from databricks.connect import DatabricksSession
 
-from student_success_tool import configs, dataio, eda, modeling, preprocessing, utils
+from student_success_tool import configs, dataio, eda, modeling, preprocessing
 from student_success_tool.preprocessing import checkpoints, selection, targets
 
 # COMMAND ----------

--- a/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
+++ b/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
@@ -24,7 +24,7 @@
 
 # install dependencies, of which most/all should come through our 1st-party SST package
 
-# %pip install "student-success-tool == 0.2.0"
+# %pip install "student-success-tool == 0.3.0"
 
 # COMMAND ----------
 

--- a/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
+++ b/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
@@ -172,7 +172,7 @@ df_student_terms.columns.tolist()
 # MAGIC df_labeled = pd.merge(df_ckpt, pd.Series(selected_students.index), how="inner", on=cfg.student_id_col)
 # MAGIC
 # MAGIC # computing target and adding it to df_labeled
-# MAGIC target = preprocessing.targets.pdp.retention.compute_target(
+# MAGIC target = targets.pdp.retention.compute_target(
 # MAGIC     df_labeled,
 # MAGIC     max_academic_year=cfg.preprocessing.target.max_academic_year,
 # MAGIC )
@@ -208,7 +208,7 @@ df_labeled
 
 # TODO: choose target function suitable for school's use case
 # parameters should be specified in the config
-target = preprocessing.targets.pdp.TODO.compute_target(
+target = targets.pdp.TODO.compute_target(
     df_labeled,
     **cfg.preprocessing.target
 )

--- a/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
+++ b/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
@@ -333,7 +333,7 @@ print(
 
 # save preprocessed dataset
 dataio.write.to_delta_table(
-    df_preprocessed, cfg.datasets.silver.preprocessed.table_path,spark_session=spark
+    df_preprocessed, cfg.datasets.silver.preprocessed.table_path, spark_session=spark
 )
 
 # COMMAND ----------

--- a/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
+++ b/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
@@ -40,7 +40,6 @@ import matplotlib.pyplot as plt
 import pandas as pd  # noqa: F401
 import seaborn as sb
 from databricks.connect import DatabricksSession
-from databricks.sdk.runtime import dbutils
 
 from student_success_tool import configs, dataio, eda, modeling, preprocessing, utils
 from student_success_tool.preprocessing import checkpoints, selection, targets

--- a/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
+++ b/pipelines/institution_id/01-preprocess-data-TEMPLATE.py
@@ -166,7 +166,7 @@ df_student_terms.columns.tolist()
 # MAGIC selected_students = selection.pdp.select_students_by_attributes(
 # MAGIC     df_student_terms,
 # MAGIC     student_id_cols=cfg.student_id_col,
-# MAGIC     **cfg.preprocessing.selection.student_criteria
+# MAGIC     **cfg.preprocessing.selection.student_criteria,
 # MAGIC )
 # MAGIC # finding students who meet student criteria in checkpoints
 # MAGIC df_labeled = pd.merge(df_ckpt, pd.Series(selected_students.index), how="inner", on=cfg.student_id_col)
@@ -197,21 +197,20 @@ df_ckpt
 selected_students = selection.pdp.select_students_by_attributes(
     df_student_terms,
     student_id_cols=cfg.student_id_col,
-    **cfg.preprocessing.selection.student_criteria
+    **cfg.preprocessing.selection.student_criteria,
 )
 
 # merge checkpoint terms with selected students
-df_labeled = pd.merge(df_ckpt, pd.Series(selected_students.index), how="inner", on=cfg.student_id_col)
+df_labeled = pd.merge(
+    df_ckpt, pd.Series(selected_students.index), how="inner", on=cfg.student_id_col
+)
 df_labeled
 
 # COMMAND ----------
 
 # TODO: choose target function suitable for school's use case
 # parameters should be specified in the config
-target = targets.pdp.TODO.compute_target(
-    df_labeled,
-    **cfg.preprocessing.target
-)
+target = targets.pdp.TODO.compute_target(df_labeled, **cfg.preprocessing.target)
 df_labeled = pd.merge(df_features, target, how="inner", on=cfg.student_id_col)
 
 print(df_labeled[cfg.target_col].value_counts())
@@ -242,9 +241,7 @@ plt.show()
 # COMMAND ----------
 
 # drop unwanted columns and mask values by time
-df_preprocessed = preprocessing.pdp.clean_up_labeled_dataset_cols_and_vals(
-    df_labeled
-)
+df_preprocessed = preprocessing.pdp.clean_up_labeled_dataset_cols_and_vals(df_labeled)
 df_preprocessed.shape
 
 # COMMAND ----------
@@ -307,9 +304,9 @@ non_feature_cols = (
 
 # COMMAND ----------
 
-target_corrs = df_preprocessed.drop(columns=non_feature_cols + [cfg.target_col]).corrwith(
-    df_preprocessed[cfg.target_col], method="spearman", numeric_only=True
-)
+target_corrs = df_preprocessed.drop(
+    columns=non_feature_cols + [cfg.target_col]
+).corrwith(df_preprocessed[cfg.target_col], method="spearman", numeric_only=True)
 print(target_corrs.sort_values(ascending=False).head(10))
 print("...")
 print(target_corrs.sort_values(ascending=False, na_position="first").tail(10))
@@ -336,9 +333,7 @@ print(
 
 # save preprocessed dataset
 dataio.write.to_delta_table(
-    df_preprocessed,
-    cfg.datasets.silver.preprocessed.table_path,
-    spark_session=spark
+    df_preprocessed, cfg.datasets.silver.preprocessed.table_path,spark_session=spark
 )
 
 # COMMAND ----------

--- a/pipelines/institution_id/02-train-model-TEMPLATE.py
+++ b/pipelines/institution_id/02-train-model-TEMPLATE.py
@@ -139,9 +139,7 @@ df = df.loc[:, df_selected.columns]
 
 # save modeling dataset with all splits
 dataio.write.to_delta_table(
-    df,
-    cfg.datasets.silver.modeling.table_path,
-    spark_session=spark
+    df, cfg.datasets.silver.modeling.table_path, spark_session=spark
 )
 
 # COMMAND ----------

--- a/pipelines/institution_id/02-train-model-TEMPLATE.py
+++ b/pipelines/institution_id/02-train-model-TEMPLATE.py
@@ -59,6 +59,9 @@ except Exception:
     logging.warning("unable to create spark session; are you in a Databricks runtime?")
     pass
 
+# Get job run id for automl run
+job_run_id = utils.databricks.get_db_widget_param("job_run_id", default="interactive")
+
 # COMMAND ----------
 
 # MAGIC %md

--- a/pipelines/institution_id/02-train-model-TEMPLATE.py
+++ b/pipelines/institution_id/02-train-model-TEMPLATE.py
@@ -266,8 +266,8 @@ mlflow.end_run()
 # COMMAND ----------
 
 # Optional: Evaluate permutation importance for top model
-# This can be used just for model diagnostics and is NOT used
-# in model cards or in our reporting process
+# NOTE: This can be used for model diagnostics. It is NOT used
+# in our standard evaluation process and not pulled into model cards.
 model = mlflow.sklearn.load_model(f"runs:/{top_run_ids[0]}/model")
 ax = modeling.evaluation.plot_features_permutation_importance(
     model,

--- a/pipelines/institution_id/02-train-model-TEMPLATE.py
+++ b/pipelines/institution_id/02-train-model-TEMPLATE.py
@@ -44,7 +44,6 @@ import matplotlib.pyplot as plt
 import mlflow
 import sklearn.metrics
 from databricks.connect import DatabricksSession
-from databricks.sdk.runtime import dbutils
 
 from student_success_tool import configs, dataio, modeling, utils
 

--- a/pipelines/institution_id/02-train-model-TEMPLATE.py
+++ b/pipelines/institution_id/02-train-model-TEMPLATE.py
@@ -28,7 +28,7 @@
 # we need to manually install a certain version of pandas and scikit-learn in order
 # for our models to load and run properly.
 
-# %pip install "student-success-tool==0.3.0"
+# %pip install "student-success-tool==0.3.1"
 # %pip install "pandas==1.5.3"
 # %pip install "scikit-learn==1.3.0"
 
@@ -66,40 +66,19 @@ except Exception:
 
 # COMMAND ----------
 
-run_type = utils.databricks.get_db_widget_param("run_type", default="train")
-dataset_name = utils.databricks.get_db_widget_param("dataset_name", default="labeled")
-# should this be "job_id" and "run_id", separately
-job_run_id = utils.databricks.get_db_widget_param("job_run_id", default="interactive")
-
-logging.info(
-    "'%s' run (id=%s) of notebook using dataset_name=%s",
-    run_type,
-    job_run_id,
-    dataset_name,
-)
-
-# COMMAND ----------
-
-assert run_type == "train"
-
-# COMMAND ----------
-
 # project configuration should be stored in a config file in TOML format
-# it'll start out with just basic info: institution_id, institution_name
-# but as each step of the pipeline gets built, more parameters will be moved
-# from hard-coded notebook variables to shareable, persistent config fields
 cfg = dataio.read_config("./config-TEMPLATE.toml", schema=configs.pdp.PDPProjectConfig)
 cfg
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC # read modeling dataset
+# MAGIC # read preprocessed dataset
 
 # COMMAND ----------
 
 df = dataio.read.from_delta_table(
-    cfg.datasets[dataset_name].preprocessed.table_path,
+    cfg.datasets.silver.preprocessed.table_path,
     spark_session=spark,
 )
 df.head()
@@ -153,6 +132,15 @@ df_selected.head()
 
 # HACK: we want to use selected columns for *all* splits, not just train
 df = df.loc[:, df_selected.columns]
+
+# COMMAND ----------
+
+# save modeling dataset with all splits
+dataio.write.to_delta_table(
+    df,
+    cfg.datasets.silver.modeling.table_path,
+    spark_session=spark
+)
 
 # COMMAND ----------
 
@@ -274,12 +262,9 @@ mlflow.end_run()
 
 # COMMAND ----------
 
-# MAGIC %md
-# MAGIC # evaluate model
-
-# COMMAND ----------
-
-# Evaluation permutation importance for top model
+# Optional: Evaluate permutation importance for top model
+# This can be used just for model diagnostics and is NOT used
+# in model cards or in our reporting process
 model = mlflow.sklearn.load_model(f"runs:/{top_run_ids[0]}/model")
 ax = modeling.evaluation.plot_features_permutation_importance(
     model,

--- a/pipelines/institution_id/02-train-model-TEMPLATE.py
+++ b/pipelines/institution_id/02-train-model-TEMPLATE.py
@@ -28,7 +28,7 @@
 # we need to manually install a certain version of pandas and scikit-learn in order
 # for our models to load and run properly.
 
-# %pip install "student-success-tool==0.2.0"
+# %pip install "student-success-tool==0.3.0"
 # %pip install "pandas==1.5.3"
 # %pip install "scikit-learn==1.3.0"
 

--- a/pipelines/institution_id/03-make-predictions-TEMPLATE.py
+++ b/pipelines/institution_id/03-make-predictions-TEMPLATE.py
@@ -26,7 +26,7 @@
 # we need to manually install a certain version of pandas and scikit-learn in order
 # for our models to load and run properly.
 
-# %pip install "student-success-tool==0.2.0"
+# %pip install "student-success-tool==0.3.0"
 # %pip install "pandas==1.5.3"
 # %pip install "scikit-learn==1.3.0"
 

--- a/pipelines/institution_id/03-make-predictions-TEMPLATE.py
+++ b/pipelines/institution_id/03-make-predictions-TEMPLATE.py
@@ -41,11 +41,9 @@ import logging
 
 import matplotlib.pyplot as plt
 import mlflow
-import numpy as np
 import pandas as pd
 import shap
 from databricks.connect import DatabricksSession
-from py4j.protocol import Py4JJavaError
 from pyspark.sql.types import FloatType, StringType, StructField, StructType
 
 from student_success_tool import configs, dataio, modeling

--- a/pipelines/institution_id/03-make-predictions-TEMPLATE.py
+++ b/pipelines/institution_id/03-make-predictions-TEMPLATE.py
@@ -231,9 +231,7 @@ shap_fig = plt.gcf()
 # HACK: plot name for shap summary needs to be hardcoded as below
 # in order to be picked up by model card module (so don't change it)
 with mlflow.start_run(run_id=cfg.model.run_id) as run:
-    mlflow.log_figure(
-        shap_fig, "shap_summary_labeled_dataset_100_ref_rows.png"
-    )
+    mlflow.log_figure(shap_fig, "shap_summary_labeled_dataset_100_ref_rows.png")
 
 # COMMAND ----------
 
@@ -279,7 +277,5 @@ result
 
 # save sample advisor output dataset
 dataio.write.to_delta_table(
-    result,
-    cfg.datasets.gold.advisor_output.table_path,
-    spark_session=spark
+    result, cfg.datasets.gold.advisor_output.table_path, spark_session=spark
 )

--- a/pipelines/institution_id/03-make-predictions-TEMPLATE.py
+++ b/pipelines/institution_id/03-make-predictions-TEMPLATE.py
@@ -234,7 +234,7 @@ shap_fig = plt.gcf()
 # save shap summary plot via mlflow into experiment artifacts folder
 with mlflow.start_run(run_id=cfg.model.run_id) as run:
     mlflow.log_figure(
-        shap_fig, f"shap_summary_sample_dataset.png"
+        shap_fig, f"shap_summary_labeled_dataset_100_ref_rows.png"
     )
 
 # COMMAND ----------

--- a/pipelines/institution_id/03-make-predictions-TEMPLATE.py
+++ b/pipelines/institution_id/03-make-predictions-TEMPLATE.py
@@ -232,10 +232,17 @@ shap.summary_plot(
 )
 shap_fig = plt.gcf()
 # save shap summary plot via mlflow into experiment artifacts folder
+# HACK: plot name for shap summary needs to be hardcoded as below
+# in order to be picked up by model card module (so don't change it)
 with mlflow.start_run(run_id=cfg.model.run_id) as run:
     mlflow.log_figure(
         shap_fig, f"shap_summary_labeled_dataset_100_ref_rows.png"
     )
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC TODO (for Vish): Add summary plot (and ranked selected features below) under the hood in SST package so we can set the paths. This will ensure alignment with model card module and no chance for user error.
 
 # COMMAND ----------
 

--- a/pipelines/institution_id/03-make-predictions-TEMPLATE.py
+++ b/pipelines/institution_id/03-make-predictions-TEMPLATE.py
@@ -38,7 +38,6 @@
 
 import functools as ft
 import logging
-import typing as t
 
 import matplotlib.pyplot as plt
 import mlflow
@@ -46,7 +45,6 @@ import numpy as np
 import pandas as pd
 import shap
 from databricks.connect import DatabricksSession
-from databricks.sdk.runtime import dbutils
 from py4j.protocol import Py4JJavaError
 from pyspark.sql.types import FloatType, StringType, StructField, StructType
 
@@ -236,7 +234,7 @@ shap_fig = plt.gcf()
 # in order to be picked up by model card module (so don't change it)
 with mlflow.start_run(run_id=cfg.model.run_id) as run:
     mlflow.log_figure(
-        shap_fig, f"shap_summary_labeled_dataset_100_ref_rows.png"
+        shap_fig, "shap_summary_labeled_dataset_100_ref_rows.png"
     )
 
 # COMMAND ----------

--- a/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
+++ b/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
@@ -50,8 +50,11 @@ except Exception:
     logging.warning("unable to create spark session; are you in a Databricks runtime?")
     pass
 
-# HACK: hardcode uc base path and mflow client
+# HACK: hardcode uc base path and mlflow client
+# NOTE: registry uri needs to be set before mlflow client
+# to avoid errors when registering the model
 catalog = "sst_dev"
+mlflow.set_registry_uri("databricks-uc")
 client = mlflow.tracking.MlflowClient()
 
 # HACK: We need to disable the mlflow widget template loading for MC output
@@ -89,7 +92,6 @@ model_name
 
 # COMMAND ----------
 
-mlflow.set_registry_uri("databricks-uc")
 modeling.registration.register_mlflow_model(
     model_name,
     cfg.institution_id,

--- a/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
+++ b/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
@@ -51,8 +51,8 @@ except Exception:
     pass
 
 # HACK: hardcode uc base path and mlflow client
-# NOTE: registry uri needs to be set before mlflow client
-# to avoid errors when registering the model
+# NOTE: registry uri needs to be set before creating the client
+# to avoid mlflow REST exception when registering the model
 catalog = "sst_dev"
 mlflow.set_registry_uri("databricks-uc")
 client = mlflow.tracking.MlflowClient()

--- a/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
+++ b/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
@@ -21,7 +21,7 @@
 # we need to manually install a certain version of pandas and scikit-learn in order
 # for our models to load and run properly.
 
-# %pip install "student-success-tool==0.2.0"
+# %pip install "student-success-tool==0.3.0"
 # %pip install "pandas==1.5.3"
 # %pip install "scikit-learn==1.3.0"
 

--- a/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
+++ b/pipelines/institution_id/04-register-model-create-card-TEMPLATE.py
@@ -21,7 +21,7 @@
 # we need to manually install a certain version of pandas and scikit-learn in order
 # for our models to load and run properly.
 
-# %pip install "student-success-tool==0.3.0"
+# %pip install "student-success-tool==0.3.1"
 # %pip install "pandas==1.5.3"
 # %pip install "scikit-learn==1.3.0"
 

--- a/src/student_success_tool/reporting/model_card/base.py
+++ b/src/student_success_tool/reporting/model_card/base.py
@@ -233,7 +233,7 @@ class ModelCard(t.Generic[C]):
             ),
             "feature_importances_by_shap_plot": (
                 "Feature Importances",
-                "shap_summary_labeled_dataset_100_ref_rows.png",
+                "shap_summary_sample_dataset.png",
                 "150mm",
             ),
         }

--- a/src/student_success_tool/reporting/model_card/base.py
+++ b/src/student_success_tool/reporting/model_card/base.py
@@ -233,7 +233,7 @@ class ModelCard(t.Generic[C]):
             ),
             "feature_importances_by_shap_plot": (
                 "Feature Importances",
-                "shap_summary_sample_dataset.png",
+                "shap_summary_labeled_dataset_100_ref_rows.png",
                 "150mm",
             ),
         }


### PR DESCRIPTION
Updated templates to most recent version v0.3.1. Per our recent team alignment, we will be using these notebooks only interactively since PDP inference will be through shared pipeline in web app.

## changes
- Updated to v0.3.1.
- Removed outdated comments and code.
- Removed language around "it is okay to add to config later and hardcode now". 
   - When users submit these notebooks for PR, we want to ensure all information is set in the config. 
   - All school-specific info needs to be in the config. No parameters should be specified from the notebooks.
- Added saving of preprocessed, modeling, and advisor output datasets.
- Removed saving of validated datasets in EDA notebook since these aren't being used anywhere else. Validated datasets are created using our converter functions in the preprocess-data notebook. 
   - We also want all datasets that are being saved to be standardized across all PDP schools, which is why we updated the config to reflect that.

## context
- Templates need to be updated to latest version and our most recent process.

## questions
- v0.3.1 looks solid, only thing that needs to be patched up is our PDP features table. We are missing several features. How do we identify all the features that are missing? One of my schools was missing the following: `took_course_course_level_0_1`, `term_program_of_study_area`, `term_program_of_study`, `took_course_course_type_cc_cd`. This needs to be patched up before our June release.