### PR TITLE
feat: implemented kayla's feedback

### DIFF
--- a/src/student_success_tool/ingestion_validation/base_schema.json
+++ b/src/student_success_tool/ingestion_validation/base_schema.json
@@ -1,0 +1,637 @@
+{
+  "version": "1.0.0",
+  "base": {
+    "data_models": {
+      "student": {
+        "required": true,
+        "columns": {
+          "student_id": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["student_id", "guid", "student_guid", "study_id"],
+            "checks": [
+              {"type": "str_length", "args": [], "kwargs": {"min_value": 3}}
+            ]
+          },
+          "first_enrollment_date": {
+            "dtype": "datetime64[ns]",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "student_type": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "first_generation_student": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["first_generation_college_student", "first_gen", "first_gen_flag", "firstgenflag"],
+            "checks": [
+              {"type": "isin", "args": [["Yes","No","Other","Unknown", "Y", "N", "0", "U"]]}
+            ]
+          },
+          "age": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["age_(range)", "age_range", "student_age", "age_group", "agegroup"],
+            "checks": []
+          },
+          "gender": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["gender_identification", "sex"],
+            "checks": [
+              {"type": "isin", "args": [["Male","Female", "M", "F", "Other","Unknown", "N", "Not specified"]]}
+            ]
+          },
+          "race": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": true,
+            "aliases": ["racial_identification", "ipeds_race"],
+            "checks": []
+          },
+          "ethnicity": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+
+          "incarceration_status": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["incarcerated_status", "incarceratedflag"],
+            "checks": [
+              {"type": "isin", "args": [["yes", "no", "Y", "N", "p", "0", "1"]]}
+            ]
+          },
+          "military_status": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["vet_type"],
+            "checks": []
+          },
+          "employment_status": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": [
+              {"type": "isin", "args": [["employed", "unemployed", "unemployed"]]}
+            ]
+          },
+          "disability_status": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["disb_flag", "disabilityflag"],
+            "checks": [
+              {"type": "isin", "args": [["yes", "no", "unknown", "Y", "N"]]}
+            ]
+          },
+          "zip_code": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["county", "zip"],
+            "checks": []
+          },
+          "high_school_completion_status": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["highschoolstatus"],
+            "checks": []
+          },
+          "high_school_completion_date": {
+            "dtype": "datetime64[ns]",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["highschoolgraddate"],
+            "checks": []
+          },
+          "high_school_unweighted_gpa": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["highschoolgpa"],
+            "checks": []
+          },
+          "high_school_weighted_gpa": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["hs_gpa"],
+            "checks": []
+          },
+          "sat_score": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "act_score": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["act_best"],
+            "checks": []
+          },
+          "credits_earned_through_ap": {
+            "dtype": "float64",
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "credits_earned_through_dual_enrollment": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "first_bachelors_graduation_date": {
+            "dtype": "datetime64[ns]",
+            "coerce": true,
+            "nullable": true,
+            "required": true,
+            "aliases": ["graduation_date", "complete_date", "grad_date", "earliestawarddate"],
+            "checks": []
+          },
+          "first_associate_graduation_date": {
+            "dtype": "datetime64[ns]",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "program_at_first_enrollment": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["program_of_study_term_1", "program_of_study_year_1"],
+            "checks": []
+          },
+          "major_at_first_enrollment": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "program_at_graduation": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "major_at_graduation": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "total_credits_attempted": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+          "total_credits_earned": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": []
+          },
+
+          "awarded_pell_ever": {
+            "dtype": "category",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["pell_status_first_year"],
+            "checks": [
+              {"type": "isin", "args": [["true", "false", "yes", "no", "Y", "N"]]}
+            ]
+          }
+        }
+      },
+
+      "semester": {
+        "required": true, 
+        "columns": {
+          "student_id": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["student_id", "guid", "student_guid", "study_id"],
+            "checks": [
+              {"type": "str_length", "args": [], "kwargs": {"min_value": 3}}
+            ]
+          },
+          "semester": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["cohort_term", "term_desc"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "enrollment_type": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["time_status"],
+            "checks": [
+              {"type": "str_length", "args": [], "kwargs": {"min_value": 1}},
+              {"type": "isin", "args": [["FT", "PT", "Others", "full_time", "part_time", "unknown"]]}
+              ]
+          },
+          "student_type": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [
+              {"type": "str_length", "args": [], "kwargs": {"min_value": 1}}
+            ]
+          },
+          "program_type_pursued": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["degree_type_pursued"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "intent_to_transfer_flag": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "pell_recipient": {
+            "dtype": "category",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["pell_status", "pell_recip_flag"],
+            "checks": [
+              {"type": "str_length", "args": [], "kwargs": {"min_value": 1}},
+              {"type": "isin", "args": [["true", "false", "unknown", "yes", "no", "Y", "N"]]}
+            ]
+          },
+          "major": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": true,
+            "aliases": ["department"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "department": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": true,
+            "aliases": ["dept", "program_name"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "cumulative_gpa": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["cum_gpa"],
+            "checks": [{"type": "in_range", "args": [0.0, 4.0]}]
+          },
+          "semester_gpa": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["sem_gpa"],
+            "checks": [{"type": "in_range", "args": [0.0, 4.0]}]
+          },
+          "number_of_courses_enrolled": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["courses_enrolled", "ug_enroll"],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "number_of_credits_attempted": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["credits_attempted", "ug_att"],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "number_of_credits_failed": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["credits_failed", "ug_fail"],
+            "checks": []
+          },
+          "number_of_credits_earned": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["credits_earned", "ug_earn"],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "course_pass_rate": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "in_range", "args": [0.0, 1.0]}]
+          },
+          "enrolled_at_another_int": {
+            "dtype": "string",
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "isin", "args": [["true", "false", "unknown", "yes", "no"]]}]
+          }
+        }
+      },
+
+      "course": {
+        "required": true,
+        "columns": {
+          "student_id": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["student id", "guid", "study_id"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 3}}]
+          },
+          "semester": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["term_desc"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "course_prefix": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["course_subject"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "course_name": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "course_number": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["course_num", "course_no", "course_number"],
+            "checks": [
+            ]
+          },
+          "course_classification": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [
+              {"type": "isin", "args": [["lecture", "lab", "seminar", "other", "schedules"]]}
+              ]
+          },
+          "course_type": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["levl_code"],
+            "checks": [
+              {"type": "isin", "args": [["undergraduates", "graduates", "development", "GED", "UG", "DS", "Undergraduate", "Graduate"]]}
+              ]
+          },
+          "core_course": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [
+              {"type": "isin", "args": [["y", "n", "yes", "no", "true", "false", "unknown", "other"]]}
+              ]
+          },
+          "pass_fail_flag": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": ["pass_fail", "pass/fail_flag"],
+            "checks": [
+              {"type": "isin", "args": [["y", "n", "Y", "N", "yes", "no", "true", "false", "unknown", "other"]]}
+              ]
+          },
+          "grade": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["course_grade", "grade_code"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "prerequisite_course_flag": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": [],
+            "checks": [
+              {"type": "isin", "args": [["Y", "N", "yes", "no", "true", "false", "unknown", "other"]]}
+              ]
+          },
+          "course_credits": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["att_hrs", "number_of_credits_attempted"],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "number_of_credits_earned": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": ["earn_hrs"],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "course_instructor_appointment_type": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "course_delivery_method": {
+            "dtype": "string",
+            "coerce": true,
+            "nullable": true,
+            "required": false,
+            "aliases": ["delivery_method", "inst_method", "modality"],
+            "checks": [
+              {"type": "str_length", "args": [], "kwargs": {"min_value": 1}}
+              ]
+          },
+          "course_begin_date": {
+            "dtype": "datetime64[ns]",
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "course_end_date": {
+            "dtype": "datetime64[ns]",
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          }
+        }
+      },
+
+      "transfer": {
+        "required": true,
+        "columns": {
+          "student_id": {
+            "dtype": "string",
+            "nullable": false,
+            "required": true,
+            "aliases": ["student id", "guid"],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 5}}]
+          },
+          "college_id_for_previous_inst": {
+            "dtype": "string",
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "years_enrolled": {
+            "dtype": "string",
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "str_length", "args": [], "kwargs": {"min_value": 1}}]
+          },
+          "number_of_credits_attempted_to_transfer": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": true,
+            "aliases": [],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "number_of_credits_successfully_transfered": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "transfer_cumulative_gpa": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "course_pass_rate": {
+            "dtype": "float64",
+            "coerce": true,
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "ge", "args": [0.0]}]
+          },
+          "associate_degree_completion": {
+            "dtype": "string",
+            "nullable": false,
+            "required": false,
+            "aliases": [],
+            "checks": [{"type": "gt", "args": [0]}]
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/student_success_tool/ingestion_validation/logger.py
+++ b/src/student_success_tool/ingestion_validation/logger.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import json
+import shutil
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+class SimpleLogger:
+    """
+    A JSONL logger that temporarily moves the institution log file to /tmp,
+    appends the new entry, and moves it back to the source directory.
+    """
+    def __init__(self, log_path: str, institution_id: Optional[str] = None):
+        self._institution_id = institution_id
+        self._final_log_path = log_path
+
+        tmp_dir = "/tmp/logs"
+        os.makedirs(tmp_dir, exist_ok=True)
+
+        # Use a temp file per institution to avoid collision
+        self._tmp_log_path = os.path.join(tmp_dir, f"{institution_id}_validation.tmp.log")
+
+        # If final log exists, move it into tmp before writing
+        if os.path.exists(self._final_log_path):
+            shutil.copy2(self._final_log_path, self._tmp_log_path)
+        else:
+            # Create empty temp log file
+            open(self._tmp_log_path, "w", encoding="utf-8").close()
+
+        # Open for appending
+        self._fh = open(self._tmp_log_path, "a", encoding="utf-8")
+
+    def _write(self, entry: Dict[str, Any]) -> None:
+        entry.setdefault("timestamp", datetime.utcnow().isoformat() + "Z")
+        line = json.dumps(entry, default=str, indent=4)
+        self._fh.write(line + "\n")
+        self._fh.flush()
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+
+    def error(
+        self,
+        message: Optional[str] = None,
+        *,
+        extra_columns: Optional[List[str]] = None,
+        missing_required: Optional[List[str]] = None,
+        schema_errors: Any = None,
+        failure_cases: Any = None
+    ) -> None:
+        entry: Dict[str, Any] = {"validation_status": "hard_error"}
+        if message:
+            entry["message"] = message
+        if extra_columns is not None:
+            entry["extra_columns"] = extra_columns
+        if missing_required is not None:
+            entry["missing_required"] = missing_required
+        if schema_errors is not None:
+            entry["schema_errors"] = schema_errors
+        if failure_cases is not None:
+            entry["failure_cases"] = failure_cases
+        self._write(entry)
+
+    def info(self, *, missing_optional: Optional[List[str]] = None) -> None:
+        status = "passed_with_soft_errors" if missing_optional else "passed"
+        entry = {
+            "validation_status": status,
+            "missing_optional": missing_optional or []
+        }
+        self._write(entry)
+
+    def exception(self, message: str = "Unexpected exception occurred") -> None:
+        exc_type, exc_val, _ = sys.exc_info()
+        entry = {
+            "validation_status": "exception",
+            "message": message,
+            "error_type": exc_type.__name__ if exc_type else None,
+            "error": str(exc_val),
+        }
+        self._write(entry)
+
+    def close(self) -> None:
+        try:
+            self._fh.close()
+            final_dir = os.path.dirname(self._final_log_path)
+            os.makedirs(final_dir, exist_ok=True)
+            shutil.move(self._tmp_log_path, self._final_log_path)
+        except Exception as e:
+            sys.stderr.write(f"[LOGGER] Failed to move final log file: {e}\n")
+
+
+def setup_logger(institution_id: Optional[str] = None, log_file: str = "validation.log") -> SimpleLogger:
+    if not institution_id:
+        raise ValueError("institution_id is required for institution-specific logging")
+
+    log_dir = f"/Volumes/staging_sst_01/{institution_id}_bronze/bronze_volume/logs"
+    log_path = os.path.join(log_dir, log_file)
+
+    return SimpleLogger(log_path=log_path, institution_id=institution_id)

--- a/src/student_success_tool/ingestion_validation/validation.py
+++ b/src/student_success_tool/ingestion_validation/validation.py
@@ -1,18 +1,33 @@
+"""
+Validate an incoming pandas DataFrame (or CSV) against one or more data models
+(from a base schema + optional institution extension) using Pandera.
+
+Reports:
+  - extra_columns: dataset cols not in the merged schema (canonical or alias)
+  - missing_required: merged-schema required cols not found in the dataset
+  - missing_optional: merged-schema optional cols not found (soft)
+  - failure_cases: row/check-level failure details (if any—treated as hard)
+"""
+
+import sys
 import json
 import os
 import re
-from typing import Union, List, Dict, Any, Optional
+import argparse
+from typing import Union, List, Dict, Any
 
 import pandas as pd
+import pandera as pa
 from pandera import Column, Check, DataFrameSchema
 from pandera.errors import SchemaErrors
 
+from logger import setup_logger
 
 class HardValidationError(Exception):
     def __init__(
         self,
-        missing_required: Any = None,
-        extra_columns: Any = None,
+        missing_required: List[str] = None,
+        extra_columns: List[str] = None,
         schema_errors: Any = None,
         failure_cases: Any = None,
     ):
@@ -31,51 +46,65 @@ class HardValidationError(Exception):
 
 
 def normalize_col(name: str) -> str:
-    return name.strip().lower().replace(" ", "_").replace("-", "_")
+    return (
+        name.strip()
+            .lower()
+            .replace(" ", "_")
+            .replace("-", "_")
+    )
 
 
-def load_json(path: str) -> Any:
+def load_json(path: str) -> dict:
     try:
-        with open(path, "r") as f:
+        with open(path, 'r') as f:
             return json.load(f)
     except Exception as e:
         raise FileNotFoundError(f"Failed to load JSON schema at {path}: {e}")
 
 
 def merge_model_columns(
-    base_schema: dict, extension_schema: Any, institution: str, model: str
-) -> dict:
-    base_models = base_schema.get("base", {}).get("data_models", {})
+    base_schema: dict,
+    extension_schema: dict,
+    institution: str,
+    model: str,
+    logger=None
+) -> Dict[str, dict]:
+    base_models = base_schema.get('base', {}).get('data_models', {})
     if model not in base_models:
+        if logger:
+            logger.error(
+                message=f"Model '{model}' not found in base schema",
+                schema_errors={"model": model}
+            )
         raise KeyError(f"Model '{model}' not in base schema")
-    merged = dict(base_models[model].get("columns", {}))
+    merged = dict(base_models[model].get('columns', {}))
     if extension_schema:
-        inst_block = extension_schema.get("institutions", {}).get(institution, {})
-        ext_models = inst_block.get("data_models", {})
+        inst_block = extension_schema.get('institutions', {}).get(institution, {})
+        ext_models = inst_block.get('data_models', {})
         if model in ext_models:
-            merged.update(ext_models[model].get("columns", {}))
+            merged.update(ext_models[model].get('columns', {}))
     return merged
 
 
 def build_schema(specs: Dict[str, dict]) -> DataFrameSchema:
     columns = {}
     for canon, spec in specs.items():
-        names = [canon] + spec.get("aliases", [])
+        names = [canon] + spec.get('aliases', [])
         pattern = r"^(?:" + "|".join(map(re.escape, names)) + r")$"
         checks = []
-        for chk in spec.get("checks", []):
-            factory = getattr(Check, chk["type"])
-            checks.append(factory(*chk.get("args", []), **chk.get("kwargs", {})))
+        for chk in spec.get('checks', []):
+            factory = getattr(Check, chk['type'])
+            checks.append(factory(*chk.get('args', []), **chk.get('kwargs', {})))
 
         columns[pattern] = Column(
-            name=pattern,
-            regex=True,
-            dtype=spec["dtype"],
-            nullable=spec["nullable"],
-            required=spec.get("required", False),
-            checks=checks or None,
-            coerce=spec.get("coerce", False),
-        )
+             name=pattern,
+             regex=True,
+             dtype=spec['dtype'],
+             nullable=spec['nullable'],
+             required=spec.get('required', False),
+             checks=checks or None,
+             coerce=spec.get('coerce', False),
+         )
     return DataFrameSchema(columns, strict=False)
 
 
@@ -83,19 +112,19 @@ def validate_dataset(
     df: Union[pd.DataFrame, str],
     models: Union[str, List[str]],
     institution_id: str,
-    base_schema_path: str = "/Volumes/staging_sst_01/default/schema/base_schema.json",
-    extension_schema_path: Optional[str] = None,
+    logger=None,
 ) -> Dict[str, Any]:
-    if extension_schema_path is None:
-        extension_schema_path = f"/Volumes/staging_sst_01/{institution_id}_bronze/schema/{institution_id}_schema_extension.json"
+    
     if isinstance(df, str):
         df = pd.read_csv(df)
     df = df.rename(columns={c: normalize_col(c) for c in df.columns})
     incoming = set(df.columns)
-
+    
     # 1) load schemas
+    base_schema_path = '/Volumes/staging_sst_01/default/schema/base_schema.json'
     base_schema = load_json(base_schema_path)
     ext_schema = None
+    extension_schema_path = f"/Volumes/staging_sst_01/{institution_id}_bronze/bronze_volume/schema/{institution_id}_schema_extension.json"
     if extension_schema_path and os.path.exists(extension_schema_path):
         ext_schema = load_json(extension_schema_path)
 
@@ -107,12 +136,20 @@ def validate_dataset(
 
     merged_specs: Dict[str, dict] = {}
     for m in model_list:
-        specs = merge_model_columns(base_schema, ext_schema, institution_id, m)
+        specs = merge_model_columns(base_schema, ext_schema, institution_id, m, logger)
         merged_specs.update(specs)
 
     # 3) build canon → set(normalized names)
     canon_to_norms: Dict[str, set] = {
-        canon: {normalize_col(alias) for alias in [canon] + spec.get("aliases", [])}
+        canon: {
+            normalize_col(alias)
+            for alias in [canon] + spec.get('aliases', [])
+        }
+        for canon, spec in merged_specs.items()
+    }
+
+    pattern_to_canon = {
+        r"^(?:" + "|".join(map(re.escape, [canon] + spec.get('aliases', []))) + r")$": canon
         for canon, spec in merged_specs.items()
     }
 
@@ -123,19 +160,28 @@ def validate_dataset(
     missing_required = [
         canon
         for canon, norms in canon_to_norms.items()
-        if merged_specs[canon].get("required", False) and norms.isdisjoint(incoming)
+        if merged_specs[canon].get('required', False)
+           and norms.isdisjoint(incoming)
     ]
 
     missing_optional = [
         canon
         for canon, norms in canon_to_norms.items()
-        if not merged_specs[canon].get("required", False) and norms.isdisjoint(incoming)
+        if not merged_specs[canon].get('required', False)
+           and norms.isdisjoint(incoming)
     ]
 
     # Hard-fail on missing required or any extra columns
     if missing_required or extra_columns:
+        if logger:
+            logger.error(
+                message="Missing required or extra columns detected",
+                missing_required=missing_required,
+                extra_columns=extra_columns
+            )
         raise HardValidationError(
-            missing_required=missing_required, extra_columns=extra_columns
+            missing_required=missing_required,
+            extra_columns=extra_columns
         )
 
     # 5) build Pandera schema & validate (hard-fail on any error)
@@ -143,23 +189,52 @@ def validate_dataset(
     try:
         schema.validate(df, lazy=True)
     except SchemaErrors as err:
-        raise HardValidationError(
-            schema_errors=err.schema_errors,
-            failure_cases=err.failure_cases.to_dict(orient="records"),
-        )
-
-    print(
-        {
-            "validation_status": (
-                "passed_with_soft_errors" if missing_optional else "passed"
-            ),
-            "missing_optional": missing_optional,
+        # TODO: Log validation failure for DS to review
+        failed_normals = set(err.failure_cases["column"])
+        failed_canons = {
+            pattern_to_canon.get(p, p)
+            for p in failed_normals
         }
-    )
+       
+        # split into required vs optional failures
+        req_failures = [
+            c for c in failed_canons
+            if merged_specs.get(c, {}).get("required", False)
+        ]
+        opt_failures = [
+            c for c in failed_canons
+            if not merged_specs.get(c, {}).get("required", False)
+        ]
+        
+        if req_failures:
+            if logger:
+                logger.error(
+                    message="Schema validation failed on required columns",
+                    schema_errors=err.schema_errors,
+                    failure_cases=err.failure_cases.to_dict(orient="records")
+                )
+            raise HardValidationError(
+                schema_errors=err.schema_errors,
+                failure_cases=err.failure_cases.to_dict(orient="records"),
+            )
+        else:
+            if logger:
+                logger.info(missing_optional=missing_optional)
+            print("Optional column validation errors on: ", opt_failures)
+            return {
+                "validation_status": "passed_with_soft_errors",
+                "missing_optional": missing_optional,
+                "optional_validation_failures": opt_failures,
+                "failure_cases": err.failure_cases.to_dict(orient="records"),
+            }
+    if logger:
+        logger.info(missing_optional=missing_optional)
     # 6) success (with possible soft misses)
     return {
         "validation_status": (
-            "passed_with_soft_errors" if missing_optional else "passed"
+            "passed_with_soft_errors"
+            if missing_optional
+            else "passed"
         ),
         "missing_optional": missing_optional,
     }


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
- Implemented SimpleLogger to write logs into each institution’s catalog
- Adjusted logger to temporarily move logs to /tmp before appending, then move them back to ensure compatibility with mounted volumes
- Modified validate_dataset to accept a logger instance and pass it explicitly

## context
These changes are part of a broader effort to improve validation traceability per institution.

## questions
No questions at this moment
