### PR TITLE
changing func to include pre_cohort parameter

### DIFF
--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -93,7 +93,7 @@ def last_student_terms(
     sort_cols: str | list[str] = "term_rank",
     include_cols: t.Optional[list[str]] = None,
     term_is_pre_cohort_col: str = "term_is_pre_cohort",
-    exclude_pre_cohort_terms: bool = True,
+    exclude_pre_cohort_terms: bool = False,
 ) -> pd.DataFrame:
     """
     For each student, get the last (-1th) row in ``df`` in ascending order of ``sort_cols`` ,

--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -43,11 +43,9 @@ def nth_student_terms(
         )
     )
     # exclude rows that are "pre-cohort", so "nth" meets our criteria here
-    df = (
-        df.loc[df[term_is_pre_cohort_col].eq(False), :]
-        if exclude_pre_cohort_terms is True
-        else df.loc[:, cols]
-    )
+    if exclude_pre_cohort_terms:
+        df = df[df[term_is_pre_cohort_col] == False]
+    df = df.loc[:, cols]
     return (
         df.sort_values(by=sort_cols, ascending=True)
         .groupby(by=student_id_cols, sort=False, as_index=False)

--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -34,10 +34,10 @@ def nth_student_terms(
     student_id_cols = utils.types.to_list(student_id_cols)
     sort_cols = utils.types.to_list(sort_cols)
     included_cols = _get_included_cols(df, student_id_cols, sort_cols, include_cols)
+    # exclude rows that are "pre-cohort", so "nth" meets our criteria here
+    if exclude_pre_cohort_terms:
+        df = df[df[term_is_pre_cohort_col] == False]
     df_nth = (
-        # exclude rows that are "pre-cohort", so "nth" meets our criteria here
-        if exclude_pre_cohort_terms:
-            df = df[df[term_is_pre_cohort_col] == False]
         df.loc[:, included_cols]
         .sort_values(
             by=(student_id_cols + sort_cols), ascending=True, ignore_index=False

--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -33,22 +33,16 @@ def nth_student_terms(
     """
     student_id_cols = utils.types.to_list(student_id_cols)
     sort_cols = utils.types.to_list(sort_cols)
-    cols = (
-        df.columns.tolist()
-        if include_cols is None
-        else list(
-            utils.misc.unique_elements_in_order(
-                student_id_cols + sort_cols + include_cols
-            )
+    included_cols = _get_included_cols(df, student_id_cols, sort_cols, include_cols)
+    df_nth = (
+        # exclude rows that are "pre-cohort", so "nth" meets our criteria here
+        if exclude_pre_cohort_terms:
+            df = df[df[term_is_pre_cohort_col] == False]
+        df.loc[:, included_cols]
+        .sort_values(
+            by=(student_id_cols + sort_cols), ascending=True, ignore_index=False
         )
-    )
-    # exclude rows that are "pre-cohort", so "nth" meets our criteria here
-    if exclude_pre_cohort_terms:
-        df = df[df[term_is_pre_cohort_col] == False]
-    df = df.loc[:, cols]
-    return (
-        df.sort_values(by=sort_cols, ascending=True)
-        .groupby(by=student_id_cols, sort=False, as_index=False)
+        .groupby(by=student_id_cols)
         .nth(n)
     )
 

--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -45,6 +45,8 @@ def nth_student_terms(
         .groupby(by=student_id_cols)
         .nth(n)
     )
+    assert isinstance(df_nth, pd.DataFrame)
+    return df_nth
 
 
 def first_student_terms(

--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -59,6 +59,8 @@ def first_student_terms(
     student_id_cols: str | list[str] = "student_id",
     sort_cols: str | list[str] = "term_rank",
     include_cols: t.Optional[list[str]] = None,
+    term_is_pre_cohort_col: str = "term_is_pre_cohort",
+    exclude_pre_cohort_terms: bool = False,
 ) -> pd.DataFrame:
     """
     For each student, get the first (0th) row in ``df`` in ascending order of ``sort_cols`` ,
@@ -79,6 +81,8 @@ def first_student_terms(
         student_id_cols=student_id_cols,
         sort_cols=sort_cols,
         include_cols=include_cols,
+        term_is_pre_cohort_col=term_is_pre_cohort_col,
+        exclude_pre_cohort_terms=exclude_pre_cohort_terms
     )
 
 
@@ -88,6 +92,8 @@ def last_student_terms(
     student_id_cols: str | list[str] = "student_id",
     sort_cols: str | list[str] = "term_rank",
     include_cols: t.Optional[list[str]] = None,
+    term_is_pre_cohort_col: str = "term_is_pre_cohort",
+    exclude_pre_cohort_terms: bool = True,
 ) -> pd.DataFrame:
     """
     For each student, get the last (-1th) row in ``df`` in ascending order of ``sort_cols`` ,
@@ -108,6 +114,8 @@ def last_student_terms(
         student_id_cols=student_id_cols,
         sort_cols=sort_cols,
         include_cols=include_cols,
+        term_is_pre_cohort_col=term_is_pre_cohort_col,
+        exclude_pre_cohort_terms=exclude_pre_cohort_terms
     )
 
 

--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -78,7 +78,7 @@ def first_student_terms(
         sort_cols=sort_cols,
         include_cols=include_cols,
         term_is_pre_cohort_col=term_is_pre_cohort_col,
-        exclude_pre_cohort_terms=exclude_pre_cohort_terms
+        exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
 
 
@@ -111,7 +111,7 @@ def last_student_terms(
         sort_cols=sort_cols,
         include_cols=include_cols,
         term_is_pre_cohort_col=term_is_pre_cohort_col,
-        exclude_pre_cohort_terms=exclude_pre_cohort_terms
+        exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
 
 

--- a/src/student_success_tool/preprocessing/checkpoints/pdp.py
+++ b/src/student_success_tool/preprocessing/checkpoints/pdp.py
@@ -15,32 +15,44 @@ def nth_student_terms(
     student_id_cols: str | list[str] = "student_id",
     sort_cols: str | list[str] = "term_rank",
     include_cols: t.Optional[list[str]] = None,
+    term_is_pre_cohort_col: str = "term_is_pre_cohort",
+    exclude_pre_cohort_terms: bool = True,
 ) -> pd.DataFrame:
     """
-    For each student, get the nth row in ``df`` , in ascending order of ``sort_cols`` ,
-    and a configurable subset of columns.
+    For each student, get the nth row in ``df`` (in ascending order of ``sort_cols`` ). If `exclude_pre_cohort_col` is true, then for each student, we want to get the nth row in ``df`` (in ascending order of ``sort_cols`` ) for which the term occurred *within* the student's cohort, i.e. not prior to their official start of enrollment, and a configurable subset of columns.
+    Ex. n = 0 gets the first term, and is equivalent to the functionality of get_first_student_terms(); n = 1 gets the second term, n = 2, gets the third term, so on and so forth.
 
     Args:
-        df: Student-term dataset.
-        n: Row number to be returned for each student, in ascending ``sort_cols`` order.
-            Note that ``n`` is zero-indexed, so 0 => first row, 1 => second row, etc.
-        student_id_cols: Column(s) that uniquely identify students in ``df`` .
-        sort_cols: Column(s) used to sort students' terms, typically chronologically.
+        df
+        n
+        student_id_cols
+        sort_cols
         include_cols
+        term_is_pre_cohort_col
+        exclude_pre_cohort_terms
     """
     student_id_cols = utils.types.to_list(student_id_cols)
     sort_cols = utils.types.to_list(sort_cols)
-    included_cols = _get_included_cols(df, student_id_cols, sort_cols, include_cols)
-    df_nth = (
-        df.loc[:, included_cols]
-        .sort_values(
-            by=(student_id_cols + sort_cols), ascending=True, ignore_index=False
+    cols = (
+        df.columns.tolist()
+        if include_cols is None
+        else list(
+            utils.misc.unique_elements_in_order(
+                student_id_cols + sort_cols + include_cols
+            )
         )
-        .groupby(by=student_id_cols)
+    )
+    # exclude rows that are "pre-cohort", so "nth" meets our criteria here
+    df = (
+        df.loc[df[term_is_pre_cohort_col].eq(False), :]
+        if exclude_pre_cohort_terms is True
+        else df.loc[:, cols]
+    )
+    return (
+        df.sort_values(by=sort_cols, ascending=True)
+        .groupby(by=student_id_cols, sort=False, as_index=False)
         .nth(n)
     )
-    assert isinstance(df_nth, pd.DataFrame)  # type guard
-    return df_nth
 
 
 def first_student_terms(

--- a/tests/preprocessing/checkpoints/test_pdp.py
+++ b/tests/preprocessing/checkpoints/test_pdp.py
@@ -63,105 +63,108 @@ def df_test():
     )
 
 
-# @pytest.mark.parametrize(
-#     ["n", "include_cols", "exp"],
-#     [
-#         (
-#             0,
-#             None,
-#             pd.DataFrame(
-#                 data={
-#                     "student_id": ["01", "02", "03", "04", "05"],
-#                     "term_rank": [3, 5, 2, 4, 8],
-#                     "cohort_id": [
-#                         "2020-21 SPRING",
-#                         "2021-22 FALL",
-#                         "2019-20 FALL",
-#                         "2020-21 SPRING",
-#                         "2022-23 FALL",
-#                     ],
-#                     "term_id": [
-#                         "2020-21 FALL",
-#                         "2021-22 FALL",
-#                         "2019-20 SPRING",
-#                         "2020-21 SPRING",
-#                         "2022-23 FALL",
-#                     ],
-#                     "enrollment_year": [1, 1, 1, 1, 1],
-#                     "enrollment_intensity": [
-#                         "FULL-TIME",
-#                         "PART-TIME",
-#                         "PART-TIME",
-#                         "FULL-TIME",
-#                         pd.NA,
-#                     ],
-#                     "num_credits_earned": [25.0, 25.0, 20.0, 45.0, 10.0],
-#                     "term_is_pre_cohort": [True, False, False, False, False],
-#                 },
-#                 index=pd.Index([0, 3, 5, 6, 7], dtype="int64"),
-#             ).astype(
-#                 {
-#                     "student_id": "string",
-#                     "cohort_id": "string",
-#                     "term_id": "string",
-#                     "enrollment_intensity": "string",
-#                 }
-#             ),
-#         ),
-#         (
-#             0,
-#             ["term_id"],
-#             pd.DataFrame(
-#                 data={
-#                     "student_id": ["01", "02", "03", "04", "05"],
-#                     "term_rank": [3, 5, 2, 4, 8],
-#                     "term_id": [
-#                         "2020-21 FALL",
-#                         "2021-22 FALL",
-#                         "2019-20 SPRING",
-#                         "2020-21 SPRING",
-#                         "2022-23 FALL",
-#                     ],
-#                 },
-#                 index=pd.Index([0, 3, 5, 6, 7], dtype="int64"),
-#             ).astype({"student_id": "string", "term_id": "string"}),
-#         ),
-#         (
-#             1,
-#             None,
-#             pd.DataFrame(
-#                 data={
-#                     "student_id": ["01", "02"],
-#                     "term_rank": [4, 6],
-#                     "cohort_id": ["2020-21 SPRING", "2021-22 FALL"],
-#                     "term_id": ["2020-21 SPRING", "2023-24 FALL"],
-#                     "enrollment_year": [1, 3],
-#                     "enrollment_intensity": ["FULL-TIME", "PART-TIME"],
-#                     "num_credits_earned": [30.0, 35.0],
-#                     "term_is_pre_cohort": [False, False],
-#                 },
-#                 index=pd.Index([1, 4], dtype="int64"),
-#             ).astype(
-#                 {
-#                     "student_id": "string",
-#                     "cohort_id": "string",
-#                     "term_id": "string",
-#                     "enrollment_intensity": "string",
-#                 }
-#             ),
-#         ),
-#     ],
-# )
-# def test_nth_student_terms(df_test, n, include_cols, exp):
-#     obs = pdp.nth_student_terms(
-#         df_test,
-#         n=n,
-#         student_id_cols="student_id",
-#         sort_cols="term_rank",
-#         include_cols=include_cols,
-#     )
-#     assert isinstance(obs, pd.DataFrame)
-#     assert pd.testing.assert_frame_equal(obs, exp) is None
+@pytest.mark.parametrize(
+    ["n", "include_cols", "exclude_pre_cohort_terms", "exp"],
+    [
+        (
+            0,
+            None,
+            False,
+            pd.DataFrame(
+                {
+                    "student_id": ["01", "02", "03", "04", "05"],
+                    "term_rank": [3, 5, 2, 4, 8],
+                    "cohort_id": [
+                        "2020-21 SPRING",
+                        "2021-22 FALL",
+                        "2019-20 FALL",
+                        "2020-21 SPRING",
+                        "2022-23 FALL",
+                    ],
+                    "term_id": [
+                        "2020-21 FALL",
+                        "2021-22 FALL",
+                        "2019-20 SPRING",
+                        "2020-21 SPRING",
+                        "2022-23 FALL",
+                    ],
+                    "enrollment_year": [1, 1, 1, 1, 1],
+                    "enrollment_intensity": [
+                        "FULL-TIME",
+                        "PART-TIME",
+                        "PART-TIME",
+                        "FULL-TIME",
+                        pd.NA,
+                    ],
+                    "num_credits_earned": [25.0, 25.0, 20.0, 45.0, 10.0],
+                    "term_is_pre_cohort": [True, False, False, False, False],
+                }
+            ).astype(
+                {
+                    "student_id": "string",
+                    "cohort_id": "string",
+                    "term_id": "string",
+                    "enrollment_intensity": "string",
+                }
+            ),
+        ),
+        (
+            0,
+            ["term_id"],
+            True,
+            pd.DataFrame(
+                {
+                    "student_id": ["01", "02", "03", "04", "05"],
+                    "term_rank": [4, 5, 2, 4, 8],
+                    "term_id": [
+                        "2020-21 SPRING",
+                        "2021-22 FALL",
+                        "2019-20 SPRING",
+                        "2020-21 SPRING",
+                        "2022-23 FALL",
+                    ],
+                }
+            ).astype({"student_id": "string", "term_id": "string"}),
+        ),
+        (
+            1,
+            None,
+            True,
+            pd.DataFrame(
+                {
+                    "student_id": ["01", "02"],
+                    "term_rank": [5, 6],
+                    "cohort_id": ["2020-21 SPRING", "2021-22 FALL"],
+                    "term_id": ["2021-22 FALL", "2023-24 FALL"],
+                    "enrollment_year": [2, 3],
+                    "enrollment_intensity": ["FULL-TIME", "PART-TIME"],
+                    "num_credits_earned": [35.0, 35.0],
+                    "term_is_pre_cohort": [False, False],
+                }
+            ).astype(
+                {
+                    "student_id": "string",
+                    "cohort_id": "string",
+                    "term_id": "string",
+                    "enrollment_intensity": "string",
+                }
+            ),
+        ),
+    ],
+)
+def test_nth_student_terms(df_test, n, include_cols, exclude_pre_cohort_terms, exp):
+    from student_success_tool.preprocessing.checkpoints import pdp
+    obs = pdp.nth_student_terms(
+        df_test,
+        n=n,
+        student_id_cols="student_id",
+        sort_cols="term_rank",
+        include_cols=include_cols,
+        term_is_pre_cohort_col="term_is_pre_cohort",
+        exclude_pre_cohort_terms=exclude_pre_cohort_terms,
+    )
+    assert isinstance(obs, pd.DataFrame)
+    assert pd.testing.assert_frame_equal(obs.reset_index(drop=True), exp.reset_index(drop=True)) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/preprocessing/checkpoints/test_pdp.py
+++ b/tests/preprocessing/checkpoints/test_pdp.py
@@ -175,6 +175,7 @@ def test_nth_student_terms(df_test, n, include_cols, exclude_pre_cohort_terms, e
     [
         (
             ["term_id"],
+            False,
             pd.DataFrame(
                 data={
                     "student_id": ["01", "02", "03", "04", "05"],
@@ -192,15 +193,17 @@ def test_nth_student_terms(df_test, n, include_cols, exclude_pre_cohort_terms, e
         ),
     ],
 )
-def test_first_student_terms(df_test, include_cols, exp):
+def test_first_student_terms(df_test, include_cols, exclude_pre_cohort_terms, exp):
     obs = pdp.first_student_terms(
         df_test,
         student_id_cols="student_id",
         sort_cols="term_rank",
         include_cols=include_cols,
+        term_is_pre_cohort_col="term_is_pre_cohort",
+        exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
     assert isinstance(obs, pd.DataFrame)
-    assert pd.testing.assert_frame_equal(obs, exp) is None
+    pd.testing.assert_frame_equal(obs.reset_index(drop=True), exp.reset_index(drop=True))
 
 
 @pytest.mark.parametrize(
@@ -208,6 +211,7 @@ def test_first_student_terms(df_test, include_cols, exp):
     [
         (
             ["term_id"],
+            False,
             pd.DataFrame(
                 data={
                     "student_id": ["01", "02", "03", "04", "05"],
@@ -225,15 +229,17 @@ def test_first_student_terms(df_test, include_cols, exp):
         ),
     ],
 )
-def test_last_student_terms(df_test, include_cols, exp):
+def test_last_student_terms(df_test, include_cols, exclude_pre_cohort_terms, exp):
     obs = pdp.last_student_terms(
         df_test,
         student_id_cols="student_id",
         sort_cols="term_rank",
         include_cols=include_cols,
+        term_is_pre_cohort_col="term_is_pre_cohort",
+        exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
     assert isinstance(obs, pd.DataFrame)
-    assert pd.testing.assert_frame_equal(obs, exp) is None
+    pd.testing.assert_frame_equal(obs.reset_index(drop=True), exp.reset_index(drop=True))
 
 
 @pytest.mark.parametrize(

--- a/tests/preprocessing/checkpoints/test_pdp.py
+++ b/tests/preprocessing/checkpoints/test_pdp.py
@@ -154,6 +154,7 @@ def df_test():
 )
 def test_nth_student_terms(df_test, n, include_cols, exclude_pre_cohort_terms, exp):
     from student_success_tool.preprocessing.checkpoints import pdp
+
     obs = pdp.nth_student_terms(
         df_test,
         n=n,
@@ -164,10 +165,13 @@ def test_nth_student_terms(df_test, n, include_cols, exclude_pre_cohort_terms, e
         exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
     assert isinstance(obs, pd.DataFrame)
-    assert pd.testing.assert_frame_equal(
-    obs.sort_values("student_id").reset_index(drop=True),
-    exp.sort_values("student_id").reset_index(drop=True)
-    ) is None
+    assert (
+        pd.testing.assert_frame_equal(
+            obs.sort_values("student_id").reset_index(drop=True),
+            exp.sort_values("student_id").reset_index(drop=True),
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(
@@ -203,7 +207,9 @@ def test_first_student_terms(df_test, include_cols, exclude_pre_cohort_terms, ex
         exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
     assert isinstance(obs, pd.DataFrame)
-    pd.testing.assert_frame_equal(obs.reset_index(drop=True), exp.reset_index(drop=True))
+    pd.testing.assert_frame_equal(
+        obs.reset_index(drop=True), exp.reset_index(drop=True)
+    )
 
 
 @pytest.mark.parametrize(
@@ -239,7 +245,9 @@ def test_last_student_terms(df_test, include_cols, exclude_pre_cohort_terms, exp
         exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
     assert isinstance(obs, pd.DataFrame)
-    pd.testing.assert_frame_equal(obs.reset_index(drop=True), exp.reset_index(drop=True))
+    pd.testing.assert_frame_equal(
+        obs.reset_index(drop=True), exp.reset_index(drop=True)
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/preprocessing/checkpoints/test_pdp.py
+++ b/tests/preprocessing/checkpoints/test_pdp.py
@@ -164,7 +164,10 @@ def test_nth_student_terms(df_test, n, include_cols, exclude_pre_cohort_terms, e
         exclude_pre_cohort_terms=exclude_pre_cohort_terms,
     )
     assert isinstance(obs, pd.DataFrame)
-    assert pd.testing.assert_frame_equal(obs.reset_index(drop=True), exp.reset_index(drop=True)) is None
+    assert pd.testing.assert_frame_equal(
+    obs.sort_values("student_id").reset_index(drop=True),
+    exp.sort_values("student_id").reset_index(drop=True)
+    ) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/preprocessing/checkpoints/test_pdp.py
+++ b/tests/preprocessing/checkpoints/test_pdp.py
@@ -63,105 +63,105 @@ def df_test():
     )
 
 
-@pytest.mark.parametrize(
-    ["n", "include_cols", "exp"],
-    [
-        (
-            0,
-            None,
-            pd.DataFrame(
-                data={
-                    "student_id": ["01", "02", "03", "04", "05"],
-                    "term_rank": [3, 5, 2, 4, 8],
-                    "cohort_id": [
-                        "2020-21 SPRING",
-                        "2021-22 FALL",
-                        "2019-20 FALL",
-                        "2020-21 SPRING",
-                        "2022-23 FALL",
-                    ],
-                    "term_id": [
-                        "2020-21 FALL",
-                        "2021-22 FALL",
-                        "2019-20 SPRING",
-                        "2020-21 SPRING",
-                        "2022-23 FALL",
-                    ],
-                    "enrollment_year": [1, 1, 1, 1, 1],
-                    "enrollment_intensity": [
-                        "FULL-TIME",
-                        "PART-TIME",
-                        "PART-TIME",
-                        "FULL-TIME",
-                        pd.NA,
-                    ],
-                    "num_credits_earned": [25.0, 25.0, 20.0, 45.0, 10.0],
-                    "term_is_pre_cohort": [True, False, False, False, False],
-                },
-                index=pd.Index([0, 3, 5, 6, 7], dtype="int64"),
-            ).astype(
-                {
-                    "student_id": "string",
-                    "cohort_id": "string",
-                    "term_id": "string",
-                    "enrollment_intensity": "string",
-                }
-            ),
-        ),
-        (
-            0,
-            ["term_id"],
-            pd.DataFrame(
-                data={
-                    "student_id": ["01", "02", "03", "04", "05"],
-                    "term_rank": [3, 5, 2, 4, 8],
-                    "term_id": [
-                        "2020-21 FALL",
-                        "2021-22 FALL",
-                        "2019-20 SPRING",
-                        "2020-21 SPRING",
-                        "2022-23 FALL",
-                    ],
-                },
-                index=pd.Index([0, 3, 5, 6, 7], dtype="int64"),
-            ).astype({"student_id": "string", "term_id": "string"}),
-        ),
-        (
-            1,
-            None,
-            pd.DataFrame(
-                data={
-                    "student_id": ["01", "02"],
-                    "term_rank": [4, 6],
-                    "cohort_id": ["2020-21 SPRING", "2021-22 FALL"],
-                    "term_id": ["2020-21 SPRING", "2023-24 FALL"],
-                    "enrollment_year": [1, 3],
-                    "enrollment_intensity": ["FULL-TIME", "PART-TIME"],
-                    "num_credits_earned": [30.0, 35.0],
-                    "term_is_pre_cohort": [False, False],
-                },
-                index=pd.Index([1, 4], dtype="int64"),
-            ).astype(
-                {
-                    "student_id": "string",
-                    "cohort_id": "string",
-                    "term_id": "string",
-                    "enrollment_intensity": "string",
-                }
-            ),
-        ),
-    ],
-)
-def test_nth_student_terms(df_test, n, include_cols, exp):
-    obs = pdp.nth_student_terms(
-        df_test,
-        n=n,
-        student_id_cols="student_id",
-        sort_cols="term_rank",
-        include_cols=include_cols,
-    )
-    assert isinstance(obs, pd.DataFrame)
-    assert pd.testing.assert_frame_equal(obs, exp) is None
+# @pytest.mark.parametrize(
+#     ["n", "include_cols", "exp"],
+#     [
+#         (
+#             0,
+#             None,
+#             pd.DataFrame(
+#                 data={
+#                     "student_id": ["01", "02", "03", "04", "05"],
+#                     "term_rank": [3, 5, 2, 4, 8],
+#                     "cohort_id": [
+#                         "2020-21 SPRING",
+#                         "2021-22 FALL",
+#                         "2019-20 FALL",
+#                         "2020-21 SPRING",
+#                         "2022-23 FALL",
+#                     ],
+#                     "term_id": [
+#                         "2020-21 FALL",
+#                         "2021-22 FALL",
+#                         "2019-20 SPRING",
+#                         "2020-21 SPRING",
+#                         "2022-23 FALL",
+#                     ],
+#                     "enrollment_year": [1, 1, 1, 1, 1],
+#                     "enrollment_intensity": [
+#                         "FULL-TIME",
+#                         "PART-TIME",
+#                         "PART-TIME",
+#                         "FULL-TIME",
+#                         pd.NA,
+#                     ],
+#                     "num_credits_earned": [25.0, 25.0, 20.0, 45.0, 10.0],
+#                     "term_is_pre_cohort": [True, False, False, False, False],
+#                 },
+#                 index=pd.Index([0, 3, 5, 6, 7], dtype="int64"),
+#             ).astype(
+#                 {
+#                     "student_id": "string",
+#                     "cohort_id": "string",
+#                     "term_id": "string",
+#                     "enrollment_intensity": "string",
+#                 }
+#             ),
+#         ),
+#         (
+#             0,
+#             ["term_id"],
+#             pd.DataFrame(
+#                 data={
+#                     "student_id": ["01", "02", "03", "04", "05"],
+#                     "term_rank": [3, 5, 2, 4, 8],
+#                     "term_id": [
+#                         "2020-21 FALL",
+#                         "2021-22 FALL",
+#                         "2019-20 SPRING",
+#                         "2020-21 SPRING",
+#                         "2022-23 FALL",
+#                     ],
+#                 },
+#                 index=pd.Index([0, 3, 5, 6, 7], dtype="int64"),
+#             ).astype({"student_id": "string", "term_id": "string"}),
+#         ),
+#         (
+#             1,
+#             None,
+#             pd.DataFrame(
+#                 data={
+#                     "student_id": ["01", "02"],
+#                     "term_rank": [4, 6],
+#                     "cohort_id": ["2020-21 SPRING", "2021-22 FALL"],
+#                     "term_id": ["2020-21 SPRING", "2023-24 FALL"],
+#                     "enrollment_year": [1, 3],
+#                     "enrollment_intensity": ["FULL-TIME", "PART-TIME"],
+#                     "num_credits_earned": [30.0, 35.0],
+#                     "term_is_pre_cohort": [False, False],
+#                 },
+#                 index=pd.Index([1, 4], dtype="int64"),
+#             ).astype(
+#                 {
+#                     "student_id": "string",
+#                     "cohort_id": "string",
+#                     "term_id": "string",
+#                     "enrollment_intensity": "string",
+#                 }
+#             ),
+#         ),
+#     ],
+# )
+# def test_nth_student_terms(df_test, n, include_cols, exp):
+#     obs = pdp.nth_student_terms(
+#         df_test,
+#         n=n,
+#         student_id_cols="student_id",
+#         sort_cols="term_rank",
+#         include_cols=include_cols,
+#     )
+#     assert isinstance(obs, pd.DataFrame)
+#     assert pd.testing.assert_frame_equal(obs, exp) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/preprocessing/checkpoints/test_pdp.py
+++ b/tests/preprocessing/checkpoints/test_pdp.py
@@ -171,7 +171,7 @@ def test_nth_student_terms(df_test, n, include_cols, exclude_pre_cohort_terms, e
 
 
 @pytest.mark.parametrize(
-    ["include_cols", "exp"],
+    ["include_cols", "exclude_pre_cohort_terms", "exp"],
     [
         (
             ["term_id"],
@@ -207,7 +207,7 @@ def test_first_student_terms(df_test, include_cols, exclude_pre_cohort_terms, ex
 
 
 @pytest.mark.parametrize(
-    ["include_cols", "exp"],
+    ["include_cols", "exclude_pre_cohort_terms", "exp"],
     [
         (
             ["term_id"],


### PR DESCRIPTION
## changes & context
We need the pre-cohort parameter for the `nth_student_term` func to work appropriately for schools who want an end of first year checkpoint (2 terms within a student's cohort)
