### PR TITLE
Remove na target values

### DIFF
--- a/mlruns/0/meta.yaml
+++ b/mlruns/0/meta.yaml
@@ -1,6 +1,0 @@
-artifact_location: file:///Users/kaylawilding/Documents/Apps/Portfolio/Github/student-success-tool/mlruns/0
-creation_time: 1749059674522
-experiment_id: '0'
-last_update_time: 1749059674522
-lifecycle_stage: active
-name: Default

--- a/mlruns/0/meta.yaml
+++ b/mlruns/0/meta.yaml
@@ -1,0 +1,6 @@
+artifact_location: file:///Users/kaylawilding/Documents/Apps/Portfolio/Github/student-success-tool/mlruns/0
+creation_time: 1749059674522
+experiment_id: '0'
+last_update_time: 1749059674522
+lifecycle_stage: active
+name: Default

--- a/src/student_success_tool/preprocessing/targets/pdp/credits_earned.py
+++ b/src/student_success_tool/preprocessing/targets/pdp/credits_earned.py
@@ -138,6 +138,8 @@ def compute_target(
     # update null targets in-place with bool targets on matching student-id indexes
     df_all_student_targets.update(df_labeled)
     # #drop if target is uncalculable (null)
-    df_all_student_targets['target'] = df_all_student_targets['target'].astype("boolean").dropna()
+    df_all_student_targets["target"] = (
+        df_all_student_targets["target"].astype("boolean").dropna()
+    )
     # return as a series with target as values and student ids as index
     return df_all_student_targets.loc[:, "target"]

--- a/src/student_success_tool/preprocessing/targets/pdp/credits_earned.py
+++ b/src/student_success_tool/preprocessing/targets/pdp/credits_earned.py
@@ -137,5 +137,7 @@ def compute_target(
     )
     # update null targets in-place with bool targets on matching student-id indexes
     df_all_student_targets.update(df_labeled)
+    # #drop if target is uncalculable (null)
+    df_all_student_targets['target'] = df_all_student_targets['target'].astype("boolean").dropna()
     # return as a series with target as values and student ids as index
     return df_all_student_targets.loc[:, "target"]

--- a/src/student_success_tool/preprocessing/targets/pdp/graduation.py
+++ b/src/student_success_tool/preprocessing/targets/pdp/graduation.py
@@ -145,8 +145,10 @@ def compute_target(
     )
     # update null targets in-place with bool targets on matching student-id indexes
     df_all_student_targets.update(df_labeled)
+    # #drop if target is uncalculable (null)
+    df_all_student_targets['target'] = df_all_student_targets['target'].astype("boolean").dropna()
     # return as a series with target as values and student ids as index
-    return df_all_student_targets.loc[:, "target"]
+    return df_all_student_targets.loc[:, "target"].dropna()
 
 
 def _mode_aggfunc(ser: pd.Series, *, dropna: bool = True) -> object:

--- a/src/student_success_tool/preprocessing/targets/pdp/graduation.py
+++ b/src/student_success_tool/preprocessing/targets/pdp/graduation.py
@@ -146,7 +146,9 @@ def compute_target(
     # update null targets in-place with bool targets on matching student-id indexes
     df_all_student_targets.update(df_labeled)
     # #drop if target is uncalculable (null)
-    df_all_student_targets['target'] = df_all_student_targets['target'].astype("boolean").dropna()
+    df_all_student_targets["target"] = (
+        df_all_student_targets["target"].astype("boolean").dropna()
+    )
     # return as a series with target as values and student ids as index
     return df_all_student_targets.loc[:, "target"].dropna()
 

--- a/src/student_success_tool/preprocessing/targets/pdp/retention.py
+++ b/src/student_success_tool/preprocessing/targets/pdp/retention.py
@@ -65,8 +65,10 @@ def compute_target(
     )
     # update null targets in-place with bool targets on matching student-id indexes
     df_all_student_targets.update(df_labeled_students)
-    #drop if target is uncalculable (null)
-    df_all_student_targets['target'] = df_all_student_targets['target'].astype("boolean").dropna()
+    # drop if target is uncalculable (null)
+    df_all_student_targets["target"] = (
+        df_all_student_targets["target"].astype("boolean").dropna()
+    )
     return df_all_student_targets.loc[:, "target"].dropna()
 
     # TODO: if we're confident that PDP computes null retention values to mean

--- a/src/student_success_tool/preprocessing/targets/pdp/retention.py
+++ b/src/student_success_tool/preprocessing/targets/pdp/retention.py
@@ -65,7 +65,9 @@ def compute_target(
     )
     # update null targets in-place with bool targets on matching student-id indexes
     df_all_student_targets.update(df_labeled_students)
-    return df_all_student_targets.loc[:, "target"]
+    #drop if target is uncalculable (null)
+    df_all_student_targets['target'] = df_all_student_targets['target'].astype("boolean").dropna()
+    return df_all_student_targets.loc[:, "target"].dropna()
 
     # TODO: if we're confident that PDP computes null retention values to mean
     # second-year data not available in the data, then we can revert to this simpler form

--- a/tests/preprocessing/targets/pdp/test_graduation.py
+++ b/tests/preprocessing/targets/pdp/test_graduation.py
@@ -54,8 +54,8 @@ from student_success_tool.preprocessing.targets.pdp import graduation
             12,
             "student_id",
             pd.Series(
-                data=[True, pd.NA],
-                index=pd.Index(["01", "02"], dtype="string", name="student_id"),
+                data=[True],
+                index=pd.Index(["01"], dtype="string", name="student_id"),
                 dtype="boolean",
                 name="target",
             ),

--- a/tests/preprocessing/targets/pdp/test_graduation.py
+++ b/tests/preprocessing/targets/pdp/test_graduation.py
@@ -145,4 +145,6 @@ def test_compute_target(
         enrollment_year_col="enrollment_year",
     )
     assert isinstance(obs, pd.Series)
+    print("obs:", obs)
+    print("exp:", exp)
     assert pd.testing.assert_series_equal(obs, exp) is None

--- a/tests/preprocessing/targets/pdp/test_retention.py
+++ b/tests/preprocessing/targets/pdp/test_retention.py
@@ -31,10 +31,8 @@ from student_success_tool.preprocessing.targets.pdp import retention
             ).astype({"student_id": "string", "retention": "boolean"}),
             "infer",
             pd.Series(
-                data=[False, True, True, pd.NA],
-                index=pd.Index(
-                    ["01", "02", "04", "03"], dtype="string", name="student_id"
-                ),
+                data=[False, True, True],
+                index=pd.Index(["01", "02", "04"], dtype="string", name="student_id"),
                 name="target",
                 dtype="boolean",
             ),
@@ -63,10 +61,8 @@ from student_success_tool.preprocessing.targets.pdp import retention
             ).astype({"student_id": "string", "retention": "Int8"}),
             "infer",
             pd.Series(
-                data=[False, True, True, pd.NA],
-                index=pd.Index(
-                    ["01", "02", "04", "03"], dtype="string", name="student_id"
-                ),
+                data=[False, True, True],
+                index=pd.Index(["01", "02", "04"], dtype="string", name="student_id"),
                 name="target",
                 dtype="boolean",
             ),
@@ -95,10 +91,8 @@ from student_success_tool.preprocessing.targets.pdp import retention
             ).astype({"student_id": "string", "retention": "boolean"}),
             "2022-23",
             pd.Series(
-                data=[False, True, pd.NA, pd.NA],
-                index=pd.Index(
-                    ["01", "02", "04", "03"], dtype="string", name="student_id"
-                ),
+                data=[False, True],
+                index=pd.Index(["01", "02"], dtype="string", name="student_id"),
                 name="target",
                 dtype="boolean",
             ),


### PR DESCRIPTION
Remove NAs from the dataset if the target is incalculable.

## changes
Updated the compute target function for grad, retention, and credits earned to drop the NA target obs before returning. Updated tests to not expect NA values in the output.

## context
When we compute the targets, previously, students with an NA value due to the fact they did not meet the eligibility criteria or have enough time left were included. Now, the code will drop these students that do not have a calculable target from the dataset. 
The NAs in the datasets were breaking graphing among other functions with this dataset.

## questions
none
