### PR TITLE
fix: prevent duplicate model registration using run-level tags

### DIFF
--- a/src/student_success_tool/modeling/registration.py
+++ b/src/student_success_tool/modeling/registration.py
@@ -19,39 +19,59 @@ def register_mlflow_model(
     mlflow_client: mlflow.tracking.MlflowClient,
 ) -> None:
     """
-    Register an mlflow model according to one of their various recommended approaches.
+    Register an MLflow model from a run, using run-level tags to prevent duplicate registration.
 
     Args:
-        model_name
-        institution_id
-        run_id
-        catalog
-        registry_uri
-        model_alias
-        mlflow_client
+        model_name: Name of the model (e.g., "student_success_model")
+        institution_id: Institution namespace
+        run_id: MLflow run ID
+        catalog: Unity Catalog (e.g., "main" or "dev")
+        registry_uri: URI for MLflow registry (default is "databricks-uc")
+        model_alias: Optional alias to set (e.g., "Staging", "Production")
+        mlflow_client: Initialized MLflowClient
 
-    References:
-        - https://mlflow.org/docs/latest/model-registry.html
+    Notes:
+        Uses the tag 'model_registered' on the run to ensure idempotency.
     """
     model_path = f"{catalog}.{institution_id}_gold.{model_name}"
     mlflow.set_registry_uri(registry_uri)
 
+    # Create the registered model if it doesn't exist
     try:
         mlflow_client.create_registered_model(name=model_path)
-        LOGGER.info("new registered model '%s' successfully created", model_path)
+        LOGGER.info("New registered model '%s' successfully created", model_path)
     except mlflow.exceptions.MlflowException as e:
         if "RESOURCE_ALREADY_EXISTS" in str(e):
-            LOGGER.info("model '%s' already created in registry", model_path)
+            LOGGER.info("Model '%s' already exists in registry", model_path)
         else:
             raise e
 
-    model_uri = get_mlflow_model_uri(run_id=run_id, model_path="model")
-    mv = mlflow_client.create_model_version(model_path, source=model_uri, run_id=run_id)
-    if model_alias is not None:
-        mlflow_client.set_registered_model_alias(
-            model_path, alias=model_alias, version=mv.version
-        )
-    LOGGER.info("model version successfully registered at '%s'", model_path)
+    # Check for the "model_registered" tag on the run
+    try:
+        run_tags = mlflow_client.get_run(run_id).data.tags
+        if run_tags.get("model_registered") == "true":
+            LOGGER.info("Run ID '%s' has already been registered. Skipping.", run_id)
+            return
+    except mlflow.exceptions.MlflowException as e:
+        LOGGER.warning("Unable to check tags for run_id '%s': %s", run_id, str(e))
+        raise
+
+    # Register new model version
+    model_uri = f"runs:/{run_id}/model"
+    result = mlflow_client.create_model_version(
+        name=model_path,
+        source=model_uri,
+        run_id=run_id,
+    )
+    LOGGER.info("Registered new model version %s from run_id '%s'", result.version, run_id)
+
+    # Mark the run as registered via tag
+    mlflow_client.set_tag(run_id, "model_registered", "true")
+
+    # Optionally assign alias
+    if model_alias:
+        mlflow_client.set_registered_model_alias(model_path, model_alias, result.version)
+        LOGGER.info("Set alias '%s' to version %s", model_alias, result.version)
 
 
 def get_model_name(

--- a/src/student_success_tool/modeling/registration.py
+++ b/src/student_success_tool/modeling/registration.py
@@ -19,19 +19,19 @@ def register_mlflow_model(
     mlflow_client: mlflow.tracking.MlflowClient,
 ) -> None:
     """
-    Register an MLflow model from a run, using run-level tags to prevent duplicate registration.
+    Register an mlflow model from a run, using run-level tags to prevent duplicate registration.
 
     Args:
-        model_name: Name of the model (e.g., "student_success_model")
-        institution_id: Institution namespace
-        run_id: MLflow run ID
-        catalog: Unity Catalog (e.g., "main" or "dev")
-        registry_uri: URI for MLflow registry (default is "databricks-uc")
-        model_alias: Optional alias to set (e.g., "Staging", "Production")
-        mlflow_client: Initialized MLflowClient
+        model_name
+        institution_id
+        run_id
+        catalog
+        registry_uri
+        model_alias
+        mlflow_client
 
-    Notes:
-        Uses the tag 'model_registered' on the run to ensure idempotency.
+    References:
+        - https://mlflow.org/docs/latest/model-registry.html
     """
     model_path = f"{catalog}.{institution_id}_gold.{model_name}"
     mlflow.set_registry_uri(registry_uri)
@@ -58,20 +58,20 @@ def register_mlflow_model(
 
     # Register new model version
     model_uri = f"runs:/{run_id}/model"
-    result = mlflow_client.create_model_version(
+    mv = mlflow_client.create_model_version(
         name=model_path,
         source=model_uri,
         run_id=run_id,
     )
-    LOGGER.info("Registered new model version %s from run_id '%s'", result.version, run_id)
+    LOGGER.info("Registered new model version %s from run_id '%s'", mv.version, run_id)
 
     # Mark the run as registered via tag
     mlflow_client.set_tag(run_id, "model_registered", "true")
 
     # Optionally assign alias
     if model_alias:
-        mlflow_client.set_registered_model_alias(model_path, model_alias, result.version)
-        LOGGER.info("Set alias '%s' to version %s", model_alias, result.version)
+        mlflow_client.set_registered_model_alias(model_path, model_alias, mv.version)
+        LOGGER.info("Set alias '%s' to version %s", model_alias, mv.version)
 
 
 def get_model_name(

--- a/tests/modeling/test_registration.py
+++ b/tests/modeling/test_registration.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import Mock, patch, call
+from unittest.mock import Mock
 import mlflow
 from student_success_tool.modeling.registration import register_mlflow_model
 

--- a/tests/modeling/test_registration.py
+++ b/tests/modeling/test_registration.py
@@ -3,10 +3,12 @@ from unittest.mock import Mock
 import mlflow
 from student_success_tool.modeling.registration import register_mlflow_model
 
+
 @pytest.fixture
 def mock_client():
     client = Mock(spec=mlflow.tracking.MlflowClient)
     return client
+
 
 def test_registers_new_model_and_sets_tag(mock_client):
     run_id = "abc123"
@@ -45,6 +47,7 @@ def test_registers_new_model_and_sets_tag(mock_client):
         model_path, "Staging", version.version
     )
 
+
 def test_skips_if_tag_indicates_already_registered(mock_client):
     mock_client.get_run.return_value.data.tags = {"model_registered": "true"}
 
@@ -60,8 +63,11 @@ def test_skips_if_tag_indicates_already_registered(mock_client):
     mock_client.set_tag.assert_not_called()
     mock_client.set_registered_model_alias.assert_not_called()
 
+
 def test_handles_existing_registered_model_gracefully(mock_client):
-    mock_client.create_registered_model.side_effect = mlflow.exceptions.MlflowException("RESOURCE_ALREADY_EXISTS")
+    mock_client.create_registered_model.side_effect = mlflow.exceptions.MlflowException(
+        "RESOURCE_ALREADY_EXISTS"
+    )
     mock_client.get_run.return_value.data.tags = {}
     mock_client.create_model_version.return_value.version = 1
 
@@ -75,6 +81,7 @@ def test_handles_existing_registered_model_gracefully(mock_client):
 
     mock_client.create_model_version.assert_called()
 
+
 def test_raises_if_tag_check_fails(mock_client):
     mock_client.get_run.side_effect = mlflow.exceptions.MlflowException("Bad request")
 
@@ -86,6 +93,7 @@ def test_raises_if_tag_check_fails(mock_client):
             catalog="main",
             mlflow_client=mock_client,
         )
+
 
 def test_skips_setting_alias_if_none(mock_client):
     mock_client.get_run.return_value.data.tags = {}

--- a/tests/modeling/test_registration.py
+++ b/tests/modeling/test_registration.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest.mock import Mock, patch, call
+import mlflow
+from student_success_tool.modeling.registration import register_mlflow_model
+
+@pytest.fixture
+def mock_client():
+    client = Mock(spec=mlflow.tracking.MlflowClient)
+    return client
+
+def test_registers_new_model_and_sets_tag(mock_client):
+    run_id = "abc123"
+    model_name = "my_model"
+    institution_id = "inst"
+    catalog = "main"
+    version = Mock()
+    version.version = 5
+
+    # Simulate: model doesn't exist → create it
+    mock_client.create_registered_model.side_effect = None
+    mock_client.get_run.return_value.data.tags = {}
+
+    mock_client.create_model_version.return_value = version
+
+    register_mlflow_model(
+        model_name=model_name,
+        institution_id=institution_id,
+        run_id=run_id,
+        catalog=catalog,
+        mlflow_client=mock_client,
+    )
+
+    model_path = f"{catalog}.{institution_id}_gold.{model_name}"
+    model_uri = f"runs:/{run_id}/model"
+
+    mock_client.create_registered_model.assert_called_once_with(name=model_path)
+    mock_client.get_run.assert_called_once_with(run_id)
+    mock_client.create_model_version.assert_called_once_with(
+        name=model_path,
+        source=model_uri,
+        run_id=run_id,
+    )
+    mock_client.set_tag.assert_called_once_with(run_id, "model_registered", "true")
+    mock_client.set_registered_model_alias.assert_called_once_with(
+        model_path, "Staging", version.version
+    )
+
+def test_skips_if_tag_indicates_already_registered(mock_client):
+    mock_client.get_run.return_value.data.tags = {"model_registered": "true"}
+
+    register_mlflow_model(
+        model_name="my_model",
+        institution_id="inst",
+        run_id="abc123",
+        catalog="main",
+        mlflow_client=mock_client,
+    )
+
+    mock_client.create_model_version.assert_not_called()
+    mock_client.set_tag.assert_not_called()
+    mock_client.set_registered_model_alias.assert_not_called()
+
+def test_handles_existing_registered_model_gracefully(mock_client):
+    mock_client.create_registered_model.side_effect = mlflow.exceptions.MlflowException("RESOURCE_ALREADY_EXISTS")
+    mock_client.get_run.return_value.data.tags = {}
+    mock_client.create_model_version.return_value.version = 1
+
+    register_mlflow_model(
+        model_name="m",
+        institution_id="inst",
+        run_id="run1",
+        catalog="main",
+        mlflow_client=mock_client,
+    )
+
+    mock_client.create_model_version.assert_called()
+
+def test_raises_if_tag_check_fails(mock_client):
+    mock_client.get_run.side_effect = mlflow.exceptions.MlflowException("Bad request")
+
+    with pytest.raises(mlflow.exceptions.MlflowException):
+        register_mlflow_model(
+            model_name="m",
+            institution_id="inst",
+            run_id="bad_run",
+            catalog="main",
+            mlflow_client=mock_client,
+        )
+
+def test_skips_setting_alias_if_none(mock_client):
+    mock_client.get_run.return_value.data.tags = {}
+    mock_client.create_model_version.return_value.version = 1
+
+    register_mlflow_model(
+        model_name="m",
+        institution_id="inst",
+        run_id="run1",
+        catalog="main",
+        model_alias=None,
+        mlflow_client=mock_client,
+    )
+
+    mock_client.set_registered_model_alias.assert_not_called()


### PR DESCRIPTION
Our process does not prevent the same run/experiment becoming continuously registered which leads to unnecessary versioning. I've had 12 versions for one of my schools by just running the template notebook (same one with model cards). I believe @nm3224 has seen the same for one of her schools too.

## changes
- Using run-level tags which are saved in mlflow tracking server, and should be accessible from any initiated client.

## context
- This is a fast way of tracking whether a run/experiment has been registered already.
- We can keep better track of our versions and not create many versions unnecessarily.

## questions
- No questions.
