### PR TITLE
fixing typo; years_to_bacheloR not years_to_bachelorS - only for "oth…

### DIFF
--- a/src/student_success_tool/preprocessing/pdp.py
+++ b/src/student_success_tool/preprocessing/pdp.py
@@ -298,9 +298,9 @@ def clean_up_labeled_dataset_cols_and_vals(
                 "persistence",
                 # years to bachelors
                 "years_to_bachelors_at_cohort_inst",
-                "years_to_bachelors_at_other_inst",
+                "years_to_bachelor_at_other_inst",
                 "first_year_to_bachelors_at_cohort_inst",
-                "first_year_to_bachelors_at_other_inst",
+                "first_year_to_bachelor_at_other_inst",
                 # years to associates
                 "years_to_latest_associates_at_cohort_inst",
                 "years_to_latest_associates_at_other_inst",

--- a/tests/preprocessing/test_pdp.py
+++ b/tests/preprocessing/test_pdp.py
@@ -217,9 +217,9 @@ def test_add_empty_cols_if_missing(df, col_val_dtypes, exp):
                     ],
                     "retention": [False, True, True, True],
                     "years_to_bachelors_at_cohort_inst": [pd.NA, pd.NA, 4, 3],
-                    "years_to_bachelors_at_other_inst": [pd.NA, 3, 2, 2],
+                    "years_to_bachelor_at_other_inst": [pd.NA, 3, 2, 2],
                     "first_year_to_bachelors_at_cohort_inst": [pd.NA, pd.NA, 4, 4],
-                    "first_year_to_bachelors_at_other_inst": [pd.NA, pd.NA, pd.NA, 6],
+                    "first_year_to_bachelor_at_other_inst": [pd.NA, pd.NA, pd.NA, 6],
                     "years_to_latest_associates_at_cohort_inst": [pd.NA, 3, 2, 2],
                     "years_to_latest_associates_at_other_inst": [pd.NA, pd.NA, 2, 1],
                     "first_year_to_associates_at_cohort_inst": [pd.NA, pd.NA, 4, 3],
@@ -269,9 +269,9 @@ def test_add_empty_cols_if_missing(df, col_val_dtypes, exp):
             ).astype(
                 {
                     "years_to_bachelors_at_cohort_inst": "Int8",
-                    "years_to_bachelors_at_other_inst": "Int8",
+                    "years_to_bachelor_at_other_inst": "Int8",
                     "first_year_to_bachelors_at_cohort_inst": "Int8",
-                    "first_year_to_bachelors_at_other_inst": "Int8",
+                    "first_year_to_bachelor_at_other_inst": "Int8",
                     "years_to_latest_associates_at_cohort_inst": "Int8",
                     "years_to_latest_associates_at_other_inst": "Int8",
                     "first_year_to_associates_at_cohort_inst": "Int8",


### PR DESCRIPTION
## changes & context

weird inconsistency i discovered in column names for first_year_to_bachelorS_at_cohort_inst and years_to_bachelorS_at_cohort_inst vs. first_year_to_bacheloR_at_other_inst and years_to_bacheloR_at_other_inst 