### PR TITLE
adding missing .dropna()

### DIFF
--- a/src/student_success_tool/preprocessing/targets/pdp/credits_earned.py
+++ b/src/student_success_tool/preprocessing/targets/pdp/credits_earned.py
@@ -142,4 +142,4 @@ def compute_target(
         df_all_student_targets["target"].astype("boolean").dropna()
     )
     # return as a series with target as values and student ids as index
-    return df_all_student_targets.loc[:, "target"]
+    return df_all_student_targets.loc[:, "target"].dropna()


### PR DESCRIPTION
## changes & context
 looking at `graduation` and `retention` I realized the `credits_earned` function was missing a .dropna() at the end. With this added, it should work.

## questions: 
- do we want to still offer schools a checkpoint other than the cohort start with this option? Because right now, `df_ckpt` is still a parameter