### PR TITLE
fix/typo & aliases for custom schools in model cards

### DIFF
--- a/src/student_success_tool/reporting/model_card/base.py
+++ b/src/student_success_tool/reporting/model_card/base.py
@@ -198,7 +198,7 @@ class ModelCard(t.Generic[C]):
             "number_of_features": str(feature_count),
             "collinearity_threshold": str(fs_cfg.collinear_threshold),
             "low_variance_threshold": str(fs_cfg.low_variance_threshold),
-            "incomplete_threshold": str(fs_cfg.incomplete_threshold),
+            "incomplete_threshold": str(int(fs_cfg.incomplete_threshold)*100),
         }
 
     def get_model_plots(self) -> dict[str, str]:

--- a/src/student_success_tool/reporting/model_card/base.py
+++ b/src/student_success_tool/reporting/model_card/base.py
@@ -198,7 +198,7 @@ class ModelCard(t.Generic[C]):
             "number_of_features": str(feature_count),
             "collinearity_threshold": str(fs_cfg.collinear_threshold),
             "low_variance_threshold": str(fs_cfg.low_variance_threshold),
-            "incomplete_threshold": str(int(fs_cfg.incomplete_threshold)*100),
+            "incomplete_threshold": str(round(fs_cfg.incomplete_threshold * 100, 2)),
         }
 
     def get_model_plots(self) -> dict[str, str]:

--- a/src/student_success_tool/reporting/model_card/base.py
+++ b/src/student_success_tool/reporting/model_card/base.py
@@ -193,7 +193,7 @@ class ModelCard(t.Generic[C]):
         def as_percent(val: float | int) -> str:
             val = float(val) * 100
             return str(int(val) if val.is_integer() else round(val, 2))
-        
+
         feature_count = len(
             self.model.named_steps["column_selector"].get_params()["cols"]
         )

--- a/src/student_success_tool/reporting/sections/custom/bias_sections.py
+++ b/src/student_success_tool/reporting/sections/custom/bias_sections.py
@@ -3,7 +3,7 @@ import logging
 import pandas as pd
 
 from .. import bias_sections as base_bias_sections
-from ..utils import utils
+from ...utils import utils
 
 LOGGER = logging.getLogger(__name__)
 

--- a/src/student_success_tool/reporting/sections/custom/bias_sections.py
+++ b/src/student_success_tool/reporting/sections/custom/bias_sections.py
@@ -18,7 +18,9 @@ def resolve_student_group_label(card, group_key):
             return card.format.friendly_case(group_key)
         return alias_dict.get(group_key, card.format.friendly_case(group_key))
     except Exception as e:
-        LOGGER.warning(f"[resolve_student_group_label] Error resolving alias for '{group_key}': {e}")
+        LOGGER.warning(
+            f"[resolve_student_group_label] Error resolving alias for '{group_key}': {e}"
+        )
         return card.format.friendly_case(group_key)
 
 
@@ -40,7 +42,9 @@ def register_bias_sections(card, registry):
 
         sg1 = card.format.bold(card.format.italic(subgroup_1))
         sg2 = card.format.bold(card.format.italic(subgroup_2))
-        percent_higher = card.format.bold(f"{int(round(float(diff) * 100))}% difference")
+        percent_higher = card.format.bold(
+            f"{int(round(float(diff) * 100))}% difference"
+        )
 
         return (
             f"- {sg1} students have a {percent_higher} in False Negative Rate (FNR) than {sg2} students. "
@@ -124,7 +128,9 @@ def register_bias_sections(card, registry):
 
         try:
             alias_dict = card.cfg.student_group_aliases
-            assert isinstance(alias_dict, dict), "student_group_aliases must be a dictionary"
+            assert isinstance(alias_dict, dict), (
+                "student_group_aliases must be a dictionary"
+            )
 
             group_labels = list(alias_dict.values())
             nested = [
@@ -134,8 +140,12 @@ def register_bias_sections(card, registry):
             return intro + "".join(nested)
 
         except (AttributeError, AssertionError, TypeError) as e:
-            LOGGER.warning(f"[bias_groups_section] Failed to extract student groups: {e}")
-            fallback = f"{card.format.indent_level(2)}- Unable to extract student groups\n"
+            LOGGER.warning(
+                f"[bias_groups_section] Failed to extract student groups: {e}"
+            )
+            fallback = (
+                f"{card.format.indent_level(2)}- Unable to extract student groups\n"
+            )
             return intro + fallback
 
     @registry.register("bias_summary_section")
@@ -147,7 +157,11 @@ def register_bias_sections(card, registry):
             LOGGER.warning(
                 "No disparities found or bias evaluation artifacts missing. Skipping bias summary section."
             )
-            return card.format.italic("No statistically significant disparities were found on test dataset across groups.")
+            return card.format.italic(
+                "No statistically significant disparities were found on test dataset across groups."
+            )
 
-        section_header = f"{card.format.header_level(4)}Disparities by Student Group\n\n"
+        section_header = (
+            f"{card.format.header_level(4)}Disparities by Student Group\n\n"
+        )
         return section_header + "\n\n".join(all_blocks)

--- a/src/student_success_tool/reporting/sections/custom/bias_sections.py
+++ b/src/student_success_tool/reporting/sections/custom/bias_sections.py
@@ -1,29 +1,132 @@
+import os
 import logging
-from .. import (
-    bias_sections as base_bias_sections,
-)
+import pandas as pd
+
+from .. import bias_sections as base_bias_sections
+from ..utils import utils
 
 LOGGER = logging.getLogger(__name__)
 
 
+def resolve_student_group_label(card, group_key):
+    try:
+        alias_dict = getattr(card.cfg, "student_group_aliases", {})
+        if not isinstance(alias_dict, dict):
+            LOGGER.warning(
+                f"[resolve_student_group_label] 'student_group_aliases' is not a dict: {type(alias_dict).__name__}"
+            )
+            return card.format.friendly_case(group_key)
+        return alias_dict.get(group_key, card.format.friendly_case(group_key))
+    except Exception as e:
+        LOGGER.warning(f"[resolve_student_group_label] Error resolving alias for '{group_key}': {e}")
+        return card.format.friendly_case(group_key)
+
+
 def register_bias_sections(card, registry):
+    # Register base sections
     base_bias_sections.register_bias_sections(card, registry)
+
+    bias_levels = ["high", "moderate", "low"]
+    group_disparities = {}
+
+    def generate_description(group, subgroups, diff, stat_summary):
+        group_label = resolve_student_group_label(card, group)
+
+        try:
+            subgroup_1, subgroup_2 = [s.strip() for s in subgroups.split("vs")]
+        except ValueError:
+            LOGGER.warning(f"Could not parse subgroups for {group}: {subgroups}")
+            return f"{card.format.bold('Could not parse subgroup comparison')}"
+
+        sg1 = card.format.bold(card.format.italic(subgroup_1))
+        sg2 = card.format.bold(card.format.italic(subgroup_2))
+        percent_higher = card.format.bold(f"{int(round(float(diff) * 100))}% difference")
+
+        return (
+            f"- {sg1} students have a {percent_higher} in False Negative Rate (FNR) than {sg2} students. "
+            f"Statistical analysis indicates {stat_summary}."
+        )
+
+    # Load bias flag CSVs and filter for test split
+    for level in bias_levels:
+        try:
+            bias_path = f"bias_flags/{level}_bias_flags.csv"
+            local_path = utils.download_artifact(
+                run_id=card.run_id,
+                local_folder=card.assets_folder,
+                artifact_path=bias_path,
+            )
+
+            if not os.path.exists(local_path):
+                LOGGER.warning(
+                    f"{level} bias flags file does not exist. Bias evaluation likely has not run."
+                )
+                continue
+
+            df = pd.read_csv(local_path)
+
+            if df.empty or "split_name" not in df.columns:
+                LOGGER.warning(
+                    f"{level} bias flags file exists but has no data or missing 'split_name' column."
+                )
+                continue
+
+            df = df[df["split_name"] == "test"]
+            if df.empty:
+                LOGGER.info(f"{level} bias flags file has no rows for test split.")
+                continue
+
+            for _, row in df.iterrows():
+                group = row["group"]
+                desc = generate_description(
+                    group,
+                    row["subgroups"],
+                    row["fnr_percentage_difference"],
+                    row["type"],
+                )
+                group_disparities.setdefault(group, []).append(desc)
+
+        except Exception as e:
+            LOGGER.warning(
+                f"Could not load {level} bias flags: [{type(e).__name__}] {str(e)}"
+            )
+
+    # Build bias summary content using student group aliases
+    all_blocks = []
+
+    for group_name, descriptions in group_disparities.items():
+        label = resolve_student_group_label(card, group_name)
+        normalized_name = group_name.lower().replace(" ", "_")
+
+        plot_artifact_path = f"fnr_plots/test_{normalized_name}_fnr.png"
+
+        try:
+            plot_md = utils.download_artifact(
+                run_id=card.run_id,
+                local_folder=card.assets_folder,
+                artifact_path=plot_artifact_path,
+                description=f"False Negative Parity Rate for {label} on Test Data",
+            )
+        except Exception as e:
+            LOGGER.warning(f"Could not load plot for {group_name}: {str(e)}")
+            plot_md = f"{card.format.bold(f'Unable to retrieve plot for {label}')}\n"
+
+        header = f"{card.format.header_level(5)}{label}\n\n"
+        text_block = "\n\n".join(descriptions)
+        all_blocks.append(header + text_block + "\n\n" + plot_md)
 
     @registry.register("bias_groups_section")
     def bias_groups_section():
         """
-        Returns bias groups for custom schools. These groups will
-        be specified in aliases (part of custom configs) for each school.
+        Returns bias groups for custom schools using aliases.
         """
         intro = f"{card.format.indent_level(1)}- Our assessment for FNR Parity was conducted across the following student groups.\n"
 
         try:
             alias_dict = card.cfg.student_group_aliases
-            assert isinstance(alias_dict, dict), (
-                "student_group_aliases must be a dictionary"
-            )
+            assert isinstance(alias_dict, dict), "student_group_aliases must be a dictionary"
 
-            group_labels = list(alias_dict.values())  # Extract the human-readable names
+            group_labels = list(alias_dict.values())
             nested = [
                 f"{card.format.indent_level(2)}- {card.format.friendly_case(label)}\n"
                 for label in group_labels
@@ -31,11 +134,20 @@ def register_bias_sections(card, registry):
             return intro + "".join(nested)
 
         except (AttributeError, AssertionError, TypeError) as e:
-            LOGGER.warning(
-                f"[bias_groups_section] Failed to extract student groups: {e}"
-            )
-
-            fallback = (
-                f"{card.format.indent_level(2)}- Unable to extract student groups\n"
-            )
+            LOGGER.warning(f"[bias_groups_section] Failed to extract student groups: {e}")
+            fallback = f"{card.format.indent_level(2)}- Unable to extract student groups\n"
             return intro + fallback
+
+    @registry.register("bias_summary_section")
+    def bias_summary_section():
+        """
+        Returns a markdown string containing the bias summary section of the model card.
+        """
+        if not all_blocks:
+            LOGGER.warning(
+                "No disparities found or bias evaluation artifacts missing. Skipping bias summary section."
+            )
+            return card.format.italic("No statistically significant disparities were found on test dataset across groups.")
+
+        section_header = f"{card.format.header_level(4)}Disparities by Student Group\n\n"
+        return section_header + "\n\n".join(all_blocks)

--- a/src/student_success_tool/reporting/sections/custom/evaluation_sections.py
+++ b/src/student_success_tool/reporting/sections/custom/evaluation_sections.py
@@ -30,6 +30,8 @@ def register_evaluation_sections(card, registry):
         try:
             aliases = card.cfg.student_group_aliases
             if isinstance(aliases, dict):
+                if group_key not in aliases.keys():
+                    LOGGER.warning("Not able to resolve group name for {group_key}.")
                 return str(aliases.get(group_key, card.format.friendly_case(group_key)))
         except Exception:
             pass

--- a/src/student_success_tool/reporting/template/model-card-TEMPLATE.md
+++ b/src/student_success_tool/reporting/template/model-card-TEMPLATE.md
@@ -32,7 +32,7 @@
             - Threshold Applied: Removed features with variance less than {low_variance_threshold}.
             - Explanation: Features with very low variance do not vary much across observations, meaning they carry little predictive signal. For example, features with variance below 0.01 are often considered near-constant.
         - Missing Data Threshold
-            - Threshold Applied: Removed features with more than {incomplete_threshold}% missing values.
+            - Threshold Applied: Removed features with {incomplete_threshold}% or more missing values.
             - Explanation: Features with a high percentage of missing values may introduce noise or require extensive imputation.
     - After our feature selection processes, {number_of_features} actionable, relevant, and non-redundant features were retained for modeling.
 - **Target Population**

--- a/tests/reporting/model_card/test_model_card.py
+++ b/tests/reporting/model_card/test_model_card.py
@@ -93,6 +93,8 @@ def test_get_feature_metadata_success(mock_config, mock_client):
     metadata = card.get_feature_metadata()
     assert metadata["number_of_features"] == "3"
     assert metadata["collinearity_threshold"] == "0.9"
+    assert metadata["low_variance_threshold"] == "0.01"
+    assert metadata["incomplete_threshold"] == "5"
 
 
 @patch("student_success_tool.reporting.model_card.base.utils.download_static_asset")

--- a/tests/reporting/sections/custom/test_bias_sections.py
+++ b/tests/reporting/sections/custom/test_bias_sections.py
@@ -13,6 +13,11 @@ def mock_card():
     formatter = Formatting()
     card.format.indent_level.side_effect = formatter.indent_level
     card.format.friendly_case.side_effect = formatter.friendly_case
+    card.format.header_level.side_effect = formatter.header_level
+    card.format.bold.side_effect = formatter.bold
+    card.format.italic.side_effect = formatter.italic
+    card.assets_folder = "/tmp/assets"
+    card.run_id = "dummy_run_id"
     return card
 
 
@@ -20,6 +25,10 @@ def mock_card():
 def registry():
     return SectionRegistry()
 
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TESTS: bias_groups_section
+# ─────────────────────────────────────────────────────────────────────────────
 
 def test_bias_groups_section_with_valid_aliases(mock_card, registry):
     mock_card.cfg.student_group_aliases = {
@@ -63,11 +72,6 @@ def test_bias_groups_section_with_aliases_that_need_friendlycase(mock_card):
 
 
 def test_bias_groups_section_with_missing_aliases(mock_card, caplog):
-    from student_success_tool.reporting.sections.custom import (
-        bias_sections as custom_bias_sections,
-    )
-    from student_success_tool.reporting.sections.registry import SectionRegistry
-
     mock_card.cfg.student_group_aliases = None
     mock_card.format.friendly_case.side_effect = lambda x: x.replace("_", " ").title()
 
@@ -82,3 +86,54 @@ def test_bias_groups_section_with_missing_aliases(mock_card, caplog):
     assert any(
         "Failed to extract student groups" in message for message in caplog.messages
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TEST: bias_summary_section uses aliases in header
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_bias_summary_section_uses_aliases(mock_card, tmp_path):
+    import pandas as pd
+    from student_success_tool.reporting.utils import utils
+
+    # Setup alias
+    mock_card.cfg.student_group_aliases = {
+        "firstgenflag": "First-Generation Students",
+    }
+
+    # Mock formatting
+    mock_card.format.friendly_case.side_effect = lambda x: x.replace("_", " ").title()
+
+    # Patch asset folder
+    mock_card.assets_folder = tmp_path
+    mock_card.run_id = "run123"
+
+    # Create bias_flags CSV
+    df = pd.DataFrame({
+        "group": ["firstgenflag"],
+        "split_name": ["test"],
+        "subgroups": ["yes vs no"],
+        "fnr_percentage_difference": [0.12],
+        "type": ["p < 0.05, 95% CI [0.05, 0.19]"]
+    })
+    bias_path = tmp_path / "bias_flags"
+    bias_path.mkdir()
+    df.to_csv(bias_path / "high_bias_flags.csv", index=False)
+
+    # Patch utils.download_artifact to just return file path
+    def mock_download_artifact(run_id, local_folder, artifact_path, description=None):
+        return tmp_path / artifact_path
+
+    utils.download_artifact = mock_download_artifact
+
+    registry = SectionRegistry()
+    custom_bias_sections.register_bias_sections(mock_card, registry)
+
+    rendered = registry.render_all()
+    result = rendered["bias_summary_section"]
+
+    print(result)
+
+    assert "First-Generation Students" in result
+    assert "12% difference" in result
+    assert "False Negative Parity Rate for First-Generation Students" in result

--- a/tests/reporting/sections/custom/test_bias_sections.py
+++ b/tests/reporting/sections/custom/test_bias_sections.py
@@ -132,4 +132,3 @@ def test_bias_summary_section_uses_aliases(mock_download_artifact, mock_card, tm
 
     assert "First-Generation" in result
     assert "12% difference" in result
-    assert "False Negative Parity Rate for First-Generation Students" in result

--- a/tests/reporting/sections/custom/test_bias_sections.py
+++ b/tests/reporting/sections/custom/test_bias_sections.py
@@ -92,6 +92,7 @@ def test_bias_groups_section_with_missing_aliases(mock_card, caplog):
 # TEST: bias_summary_section uses aliases in header
 # ─────────────────────────────────────────────────────────────────────────────
 
+@patch("student_success_tool.reporting.utils.utils.download_artifact")
 def test_bias_summary_section_uses_aliases(mock_card, tmp_path):
     import pandas as pd
     from student_success_tool.reporting.utils import utils

--- a/tests/reporting/sections/custom/test_bias_sections.py
+++ b/tests/reporting/sections/custom/test_bias_sections.py
@@ -31,6 +31,7 @@ def registry():
 # TESTS: bias_groups_section
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def test_bias_groups_section_with_valid_aliases(mock_card, registry):
     mock_card.cfg.student_group_aliases = {
         "firstgenflag": "First-Generation Status",
@@ -93,6 +94,7 @@ def test_bias_groups_section_with_missing_aliases(mock_card, caplog):
 # TEST: bias_summary_section uses aliases in header
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 @patch("student_success_tool.reporting.utils.utils.download_artifact")
 def test_bias_summary_section_uses_aliases(mock_download_artifact, mock_card, tmp_path):
     import pandas as pd
@@ -107,13 +109,15 @@ def test_bias_summary_section_uses_aliases(mock_download_artifact, mock_card, tm
     mock_card.run_id = "run123"
 
     # Write test CSV
-    df = pd.DataFrame({
-        "group": ["firstgenflag"],
-        "split_name": ["test"],
-        "subgroups": ["yes vs no"],
-        "fnr_percentage_difference": [0.12],
-        "type": ["p < 0.05, 95% CI [0.05, 0.19]"]
-    })
+    df = pd.DataFrame(
+        {
+            "group": ["firstgenflag"],
+            "split_name": ["test"],
+            "subgroups": ["yes vs no"],
+            "fnr_percentage_difference": [0.12],
+            "type": ["p < 0.05, 95% CI [0.05, 0.19]"],
+        }
+    )
     bias_path = tmp_path / "bias_flags"
     bias_path.mkdir()
     df.to_csv(bias_path / "high_bias_flags.csv", index=False)

--- a/tests/reporting/sections/custom/test_bias_sections.py
+++ b/tests/reporting/sections/custom/test_bias_sections.py
@@ -99,7 +99,7 @@ def test_bias_summary_section_uses_aliases(mock_download_artifact, mock_card, tm
 
     # Setup alias
     mock_card.cfg.student_group_aliases = {
-        "firstgenflag": "First-Generation Students",
+        "firstgenflag": "First-Generation",
     }
 
     mock_card.format.friendly_case.side_effect = lambda x: x.replace("_", " ").title()
@@ -130,6 +130,6 @@ def test_bias_summary_section_uses_aliases(mock_download_artifact, mock_card, tm
     rendered = registry.render_all()
     result = rendered["bias_summary_section"]
 
-    assert "First-Generation Students" in result
+    assert "First-Generation" in result
     assert "12% difference" in result
     assert "False Negative Parity Rate for First-Generation Students" in result

--- a/tests/reporting/sections/custom/test_bias_sections.py
+++ b/tests/reporting/sections/custom/test_bias_sections.py
@@ -25,8 +25,8 @@ def test_bias_groups_section_with_valid_aliases(mock_card, registry):
     mock_card.cfg.student_group_aliases = {
         "firstgenflag": "First-Generation Status",
         "gender": "Gender",
-        "ethnic": "Ethnicity",
-        "race_demo": "Race",
+        "ethnicity_ipeds": "Ethnicity",
+        "demo_race": "Race",
     }
 
     custom_bias_sections.register_bias_sections(mock_card, registry)

--- a/tests/reporting/sections/custom/test_bias_sections.py
+++ b/tests/reporting/sections/custom/test_bias_sections.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import MagicMock
+from unittest.mock import patch
 from student_success_tool.reporting.sections.registry import SectionRegistry
 from student_success_tool.reporting.sections.custom import (
     bias_sections as custom_bias_sections,
@@ -93,23 +94,19 @@ def test_bias_groups_section_with_missing_aliases(mock_card, caplog):
 # ─────────────────────────────────────────────────────────────────────────────
 
 @patch("student_success_tool.reporting.utils.utils.download_artifact")
-def test_bias_summary_section_uses_aliases(mock_card, tmp_path):
+def test_bias_summary_section_uses_aliases(mock_download_artifact, mock_card, tmp_path):
     import pandas as pd
-    from student_success_tool.reporting.utils import utils
 
     # Setup alias
     mock_card.cfg.student_group_aliases = {
         "firstgenflag": "First-Generation Students",
     }
 
-    # Mock formatting
     mock_card.format.friendly_case.side_effect = lambda x: x.replace("_", " ").title()
-
-    # Patch asset folder
     mock_card.assets_folder = tmp_path
     mock_card.run_id = "run123"
 
-    # Create bias_flags CSV
+    # Write test CSV
     df = pd.DataFrame({
         "group": ["firstgenflag"],
         "split_name": ["test"],
@@ -121,19 +118,17 @@ def test_bias_summary_section_uses_aliases(mock_card, tmp_path):
     bias_path.mkdir()
     df.to_csv(bias_path / "high_bias_flags.csv", index=False)
 
-    # Patch utils.download_artifact to just return file path
-    def mock_download_artifact(run_id, local_folder, artifact_path, description=None):
-        return tmp_path / artifact_path
+    # Patch return of download_artifact
+    def download_side_effect(run_id, local_folder, artifact_path, description=None):
+        return str(tmp_path / artifact_path)  # ← ensure string return
 
-    utils.download_artifact = mock_download_artifact
+    mock_download_artifact.side_effect = download_side_effect
 
+    # Run
     registry = SectionRegistry()
     custom_bias_sections.register_bias_sections(mock_card, registry)
-
     rendered = registry.render_all()
     result = rendered["bias_summary_section"]
-
-    print(result)
 
     assert "First-Generation Students" in result
     assert "12% difference" in result


### PR DESCRIPTION
## changes
- Applicable for PDP & Custom: Feature selection's incomplete threshold (missing data threshold) was not formatted correctly in the base model card class, which affects both PDP and custom schools. Before `incomplete_threshold=0.2` would show up as 0.2% in the model card, so I fixed it to show up as 20%.
-  Applicable for PDP & Custom: If `split_col` doesn't exist in the training data then this breaks the build step, so adding a raising of Validation error in case it doesn't exist.
- Applicable to only Custom: Aliases are showing up correctly in most places, but it did not show up correctly in the "Disparities by Student Group" section which shows the flagged FNR plots. I realized this wasn't showing up because I didn't create the override! It was still using the base bias section, which is why nothing broke but we need to create an override for the alias to show up (otherwise it's just "friendly case" formatting). So, for example if in the `cfg.student_group_aliases`, we have `ethnicity_ipeds = "Ethnicity"`, then this would only show up as "Ethnicity Ipeds" under this section and not the alias which is "Ethnicity". 

## context
- Mostly minor typo/wording changes, but important for optimal clarity in the model cards.

## questions
- These are three changes all grouped into one PR, but let me know if you have any concerns.