### PR TITLE
feat/h2o templates cleanup

### DIFF
--- a/pipelines/custom/institution_id/config-TEMPLATE.toml
+++ b/pipelines/custom/institution_id/config-TEMPLATE.toml
@@ -41,7 +41,7 @@ predict_file_path = "/Volumes/CATALOG/INST_ID_bronze/.../FILE_NAME_semester_infe
 
 [datasets.silver.cohort]
 train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_cohort_train"
-predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_preprocessed_inference"
+predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_cohort_inference"
 
 [datasets.silver.course]
 train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_course_train"
@@ -50,6 +50,10 @@ predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_course_inference"
 [datasets.silver.semester]
 train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_semester_train"
 predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_semester_inference"
+
+[datasets.silver.preprocessed]
+primary_keys = ["student_id"]
+train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_preprocessed_train"
 
 [datasets.silver.modeling]
 primary_keys = ["student_id"]

--- a/pipelines/custom/institution_id/h2o/03-make-h2o-predictions-TEMPLATE.py
+++ b/pipelines/custom/institution_id/h2o/03-make-h2o-predictions-TEMPLATE.py
@@ -39,7 +39,7 @@ from databricks.connect import DatabricksSession
 
 from student_success_tool import configs, dataio, modeling
 from student_success_tool.modeling import h2o_modeling
-
+from py4j.protocol import Py4JJavaError
 
 import h2o
 

--- a/pipelines/custom/institution_id/h2o/config-TEMPLATE.toml
+++ b/pipelines/custom/institution_id/h2o/config-TEMPLATE.toml
@@ -41,7 +41,7 @@ predict_file_path = "/Volumes/CATALOG/INST_ID_bronze/.../FILE_NAME_semester_infe
 
 [datasets.silver.cohort]
 train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_cohort_train"
-predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_preprocessed_inference"
+predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_cohort_inference"
 
 [datasets.silver.course]
 train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_course_train"
@@ -50,6 +50,10 @@ predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_course_inference"
 [datasets.silver.semester]
 train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_semester_train"
 predict_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_semester_inference"
+
+[datasets.silver.preprocessed]
+primary_keys = ["student_id"]
+train_table_path = "CATALOG.INST_ID_silver.DATASET_NAME_preprocessed_train"
 
 [datasets.silver.modeling]
 primary_keys = ["student_id"]

--- a/pipelines/pdp/institution_id/01-preprocess-data-TEMPLATE.py
+++ b/pipelines/pdp/institution_id/01-preprocess-data-TEMPLATE.py
@@ -323,7 +323,9 @@ if splits:
     df_preprocessed = df_preprocessed.assign(
         **{
             split_col: ft.partial(
-                modeling.utils.compute_dataset_splits, seed=cfg.random_state
+                modeling.utils.compute_dataset_splits,
+                seed=cfg.random_state,
+                stratify_col=cfg.target_col,
             )
         }
     )

--- a/src/student_success_tool/modeling/h2o_modeling/training.py
+++ b/src/student_success_tool/modeling/h2o_modeling/training.py
@@ -147,20 +147,20 @@ def run_h2o_automl_classification(
     processed_model_features = [c for c in train.columns if c not in exclude_cols]
     LOGGER.info(f"Running H2O AutoML with {len(processed_model_features)} features...")
 
-    # Create stopping criteria based on dataset size
-    n_rows = int(train.nrows)
-    if n_rows < 1500:
-        nfolds = 10
-    else:
-        nfolds = 5
+    # # Create stopping criteria based on dataset size
+    # n_rows = int(train.nrows)
+    # if n_rows < 1500:
+    #     nfolds = 10
+    # else:
+    #     nfolds = 5
 
-    LOGGER.info(
-        "H2O AutoML config -> training_rows=%d, nfolds=%d, metric=%s, include_algos=%s",
-        n_rows,
-        nfolds,
-        metric,
-        ",".join(frameworks),
-    )
+    # LOGGER.info(
+    #     "H2O AutoML config -> training_rows=%d, nfolds=%d, metric=%s, include_algos=%s",
+    #     n_rows,
+    #     nfolds,
+    #     metric,
+    #     ",".join(frameworks),
+    # )
 
     aml = H2OAutoML(
         max_runtime_secs=timeout_minutes * 60,
@@ -169,7 +169,7 @@ def run_h2o_automl_classification(
         seed=seed,
         verbosity="info",
         include_algos=frameworks,
-        nfolds=nfolds,
+        nfolds=0,
     )
 
     # Only pass weights_column if it exists in the data
@@ -177,6 +177,7 @@ def run_h2o_automl_classification(
         x=processed_model_features,
         y=target_col,
         training_frame=train,
+        validation_frame=valid,
         leaderboard_frame=valid,
     )
     if sample_weight_col in df.columns:

--- a/src/student_success_tool/modeling/h2o_modeling/training.py
+++ b/src/student_success_tool/modeling/h2o_modeling/training.py
@@ -149,23 +149,17 @@ def run_h2o_automl_classification(
 
     # Create stopping criteria based on dataset size
     n_rows = int(train.nrows)
-    if n_rows < 3000:
+    if n_rows < 1500:
         nfolds = 10
-        stopping_tolerance = 3e-4
-        stopping_rounds = 10
     else:
         nfolds = 5
-        stopping_tolerance = 1e-4
-        stopping_rounds = 5
 
     LOGGER.info(
         "H2O AutoML config -> training_rows=%d, nfolds=%d, "
-        "metric=%s, stopping_tolerance=%.1e, stopping_rounds=%d, include_algos=%s",
+        "metric=%s, include_algos=%s",
         n_rows,
         nfolds,
         metric,
-        stopping_tolerance,
-        stopping_rounds,
         ",".join(frameworks),
     )
 
@@ -176,9 +170,7 @@ def run_h2o_automl_classification(
         seed=seed,
         verbosity="info",
         include_algos=frameworks,
-        nfolds=nfolds,
-        stopping_tolerance=stopping_tolerance,
-        stopping_rounds=stopping_rounds,
+        nfolds=nfolds
     )
 
     # Only pass weights_column if it exists in the data
@@ -186,7 +178,6 @@ def run_h2o_automl_classification(
         x=processed_model_features,
         y=target_col,
         training_frame=train,
-        validation_frame=valid,
         leaderboard_frame=valid,
     )
     if sample_weight_col in df.columns:

--- a/src/student_success_tool/modeling/h2o_modeling/training.py
+++ b/src/student_success_tool/modeling/h2o_modeling/training.py
@@ -147,21 +147,6 @@ def run_h2o_automl_classification(
     processed_model_features = [c for c in train.columns if c not in exclude_cols]
     LOGGER.info(f"Running H2O AutoML with {len(processed_model_features)} features...")
 
-    # Create stopping criteria based on dataset size
-    n_rows = int(train.nrows)
-    if n_rows < 1500:
-        nfolds = 10
-    else:
-        nfolds = 5
-
-    LOGGER.info(
-        "H2O AutoML config -> training_rows=%d, nfolds=%d, metric=%s, include_algos=%s",
-        n_rows,
-        nfolds,
-        metric,
-        ",".join(frameworks),
-    )
-
     aml = H2OAutoML(
         max_runtime_secs=timeout_minutes * 60,
         sort_metric=metric,
@@ -169,7 +154,7 @@ def run_h2o_automl_classification(
         seed=seed,
         verbosity="info",
         include_algos=frameworks,
-        nfolds=nfolds,
+        nfolds=5,
     )
 
     # Only pass weights_column if it exists in the data

--- a/src/student_success_tool/modeling/h2o_modeling/training.py
+++ b/src/student_success_tool/modeling/h2o_modeling/training.py
@@ -147,20 +147,20 @@ def run_h2o_automl_classification(
     processed_model_features = [c for c in train.columns if c not in exclude_cols]
     LOGGER.info(f"Running H2O AutoML with {len(processed_model_features)} features...")
 
-    # # Create stopping criteria based on dataset size
-    # n_rows = int(train.nrows)
-    # if n_rows < 1500:
-    #     nfolds = 10
-    # else:
-    #     nfolds = 5
+    # Create stopping criteria based on dataset size
+    n_rows = int(train.nrows)
+    if n_rows < 1500:
+        nfolds = 10
+    else:
+        nfolds = 5
 
-    # LOGGER.info(
-    #     "H2O AutoML config -> training_rows=%d, nfolds=%d, metric=%s, include_algos=%s",
-    #     n_rows,
-    #     nfolds,
-    #     metric,
-    #     ",".join(frameworks),
-    # )
+    LOGGER.info(
+        "H2O AutoML config -> training_rows=%d, nfolds=%d, metric=%s, include_algos=%s",
+        n_rows,
+        nfolds,
+        metric,
+        ",".join(frameworks),
+    )
 
     aml = H2OAutoML(
         max_runtime_secs=timeout_minutes * 60,
@@ -169,7 +169,7 @@ def run_h2o_automl_classification(
         seed=seed,
         verbosity="info",
         include_algos=frameworks,
-        nfolds=0,
+        nfolds=nfolds,
     )
 
     # Only pass weights_column if it exists in the data
@@ -177,7 +177,6 @@ def run_h2o_automl_classification(
         x=processed_model_features,
         y=target_col,
         training_frame=train,
-        validation_frame=valid,
         leaderboard_frame=valid,
     )
     if sample_weight_col in df.columns:

--- a/src/student_success_tool/modeling/h2o_modeling/training.py
+++ b/src/student_success_tool/modeling/h2o_modeling/training.py
@@ -155,8 +155,7 @@ def run_h2o_automl_classification(
         nfolds = 5
 
     LOGGER.info(
-        "H2O AutoML config -> training_rows=%d, nfolds=%d, "
-        "metric=%s, include_algos=%s",
+        "H2O AutoML config -> training_rows=%d, nfolds=%d, metric=%s, include_algos=%s",
         n_rows,
         nfolds,
         metric,
@@ -170,7 +169,7 @@ def run_h2o_automl_classification(
         seed=seed,
         verbosity="info",
         include_algos=frameworks,
-        nfolds=nfolds
+        nfolds=nfolds,
     )
 
     # Only pass weights_column if it exists in the data

--- a/src/student_success_tool/modeling/h2o_modeling/utils.py
+++ b/src/student_success_tool/modeling/h2o_modeling/utils.py
@@ -13,8 +13,12 @@ from mlflow.models import Model, infer_signature
 from mlflow.tracking import MlflowClient
 import pandas as pd
 import numpy as np
-from pandas.api.types import is_categorical_dtype, is_object_dtype, is_string_dtype
-
+from pandas.api.types import (
+    is_categorical_dtype,
+    is_object_dtype,
+    is_string_dtype,
+    is_integer_dtype,
+)
 
 import h2o
 from h2o.automl import H2OAutoML
@@ -58,6 +62,8 @@ def safe_h2o_init(base_port: int = 54321, mem_per_cluster: str = "4G") -> None:
         LOGGER.warning(
             "H2O is not bound to localhost. This may expose REST endpoints on the network."
         )
+    # Stop H2O progress bars globally
+    h2o.no_progress()
 
 
 def download_artifact_file(
@@ -381,6 +387,13 @@ def log_h2o_model(
                 y_pred_sample = model.predict(sample_hf).as_data_frame()
             if hasattr(y_pred_sample, "as_data_frame"):
                 y_pred_sample = y_pred_sample.as_data_frame()
+
+            X_sample = X_sample.copy()
+            maybe_na_ints = [
+                c for c in X_sample.columns if is_integer_dtype(X_sample[c].dtype)
+            ]
+            for c in maybe_na_ints:
+                X_sample[c] = X_sample[c].astype("float64")
 
             signature = infer_signature(X_sample, y_pred_sample)
 

--- a/src/student_success_tool/modeling/h2o_modeling/utils.py
+++ b/src/student_success_tool/modeling/h2o_modeling/utils.py
@@ -347,13 +347,14 @@ def log_h2o_model(
                         y_true, y_pred, y_proba, prefix=split_name
                     )
 
-            # params + metrics (use the batched version you implemented)
-            log_model_metadata_to_mlflow(
-                model_id=model_id,
-                model=model,
-                metrics=metrics,
-                exclude_keys={"model_id"},
-            )
+            with _suppress_output():
+                # params + metrics (use the batched version you implemented)
+                log_model_metadata_to_mlflow(
+                    model_id=model_id,
+                    model=model,
+                    metrics=metrics,
+                    exclude_keys={"model_id"},
+                )
 
             # signature + UC artifacts (avoid full-train predict)
             # sample a small slice from the H2OFrame for signature inference
@@ -383,13 +384,14 @@ def log_h2o_model(
 
             signature = infer_signature(X_sample, y_pred_sample)
 
-            # Optimized UC logger
-            log_h2o_model_metadata_for_uc(
-                h2o_model=model,
-                artifact_path="model",
-                signature=signature,
-                # include_env_files=False by default for speed
-            )
+            with _suppress_output():
+                # Optimized UC logger
+                log_h2o_model_metadata_for_uc(
+                    h2o_model=model,
+                    artifact_path="model",
+                    signature=signature,
+                    # include_env_files=False by default for speed
+                )
 
             # imputer artifacts
             if imputer is not None:

--- a/src/student_success_tool/modeling/utils.py
+++ b/src/student_success_tool/modeling/utils.py
@@ -5,9 +5,9 @@ import tomlkit
 from tomlkit.items import Table
 
 
-import numpy as np
 import pandas as pd
 import sklearn.utils
+from sklearn.model_selection import train_test_split
 
 import pydantic as pyd
 
@@ -21,52 +21,67 @@ S = t.TypeVar("S", bound=pyd.BaseModel)
 def compute_dataset_splits(
     df: pd.DataFrame,
     *,
-    label_fracs: t.Optional[dict[str, float]] = None,
     stratify_col: t.Optional[str] = None,
+    label_fracs: t.Optional[dict[str, float]] = None,
     seed: t.Optional[int] = None,
+    shuffle: bool = True,
 ) -> pd.Series:
     """
-    Random 3-way split with optional stratification by target.
-    Preserves reproducibility with numpy RNG.
+    Assign each row of a DataFrame to "train", "validate", or "test"
+    according to user-specified fractions. Wraps sklearn's
+    ``train_test_split`` to ensure stratification, reproducibility,
+    and exact partitioning with no leftover rows.
+
+    Parameters:
+    df: The input dataset to split.
+    stratify_col: Column name to use for stratified sampling (e.g., the target label).
+    label_fracs: Mapping of {"train": x, "validate": y, "test": z}.
+    seed: Random seed passed to sklearn for reproducibility.
+    shuffle: Whether to shuffle rows before splitting.
+
+    Returns:
+        pd.Series: A Series of dtype "string" aligned to ``df.index`` with values
+        in {"train", "validate", "test"}.
     """
     if label_fracs is None:
         label_fracs = _DEFAULT_SPLIT_LABEL_FRACS
 
-    labels = ["train", "validate", "test"]
-    p = np.array([label_fracs[l] for l in labels], dtype=float)
-    p = p / p.sum()
+    # Normalize fractions
+    total = sum(label_fracs.values())
+    fracs = {k: v / total for k, v in label_fracs.items()}
 
-    rng = np.random.default_rng(seed=seed)
+    train_frac = fracs["train"]
+    valid_frac = fracs["validate"]
+    test_frac = fracs["test"]
+
+    stratify_vec = df[stratify_col] if stratify_col else None
+
+    # train vs temp
+    df_train, df_temp = train_test_split(
+        df,
+        test_size=(1 - train_frac),
+        stratify=stratify_vec,
+        random_state=seed,
+        shuffle=shuffle,
+    )
+
+    # validate vs test (within temp)
+    valid_size = valid_frac / (valid_frac + test_frac)
+    stratify_vec_temp = df_temp[stratify_col] if stratify_col else None
+    df_valid, df_test = train_test_split(
+        df_temp,
+        test_size=(1 - valid_size),
+        stratify=stratify_vec_temp,
+        random_state=seed,
+        shuffle=shuffle,
+    )
+
+    # Build final split Series
     split = pd.Series(index=df.index, dtype="string", name="split")
-
-    if stratify_col is None or stratify_col not in df.columns:
-        # Unstratified
-        choice = rng.choice(labels, size=len(df), p=p)
-        split[:] = choice
-        return split
-
-    # Stratified: shuffle indices within each class, then allocate
-    y = pd.Categorical(df[stratify_col])
-    for cls in y.categories:
-        idx = df.index[y == cls]
-        n = len(idx)
-        if n == 0:
-            continue
-
-        # randomize order within this class
-        idx_shuffled = rng.permutation(idx)
-
-        # split counts for this class
-        n_train = int(round(p[0] * n))
-        n_valid = int(round(p[1] * n))
-        # whatever's left goes to test
-        n_test = n - n_train - n_valid
-
-        split.loc[idx_shuffled[:n_train]] = "train"
-        split.loc[idx_shuffled[n_train : n_train + n_valid]] = "validate"
-        split.loc[idx_shuffled[n_train + n_valid :]] = "test"
-
-    return split.astype("string")
+    split.loc[df_train.index] = "train"
+    split.loc[df_valid.index] = "validate"
+    split.loc[df_test.index] = "test"
+    return split
 
 
 def compute_sample_weights(

--- a/src/student_success_tool/modeling/utils.py
+++ b/src/student_success_tool/modeling/utils.py
@@ -22,36 +22,51 @@ def compute_dataset_splits(
     df: pd.DataFrame,
     *,
     label_fracs: t.Optional[dict[str, float]] = None,
-    shuffle: bool = True,
+    stratify_col: t.Optional[str] = None,
     seed: t.Optional[int] = None,
 ) -> pd.Series:
     """
-    Split input dataset into random subsets with configurable proportions;
-    by default, Databricks' standard train/test/validate splits are generated.
-
-    Args:
-        df
-        label_fracs: Mapping of subset label to the (approximate) proportion of ``df``
-            that gets split into it.
-        shuffle: Whether or not to shuffle the data before splitting.
-        seed: Optional integer used to set state for the underlying random generator;
-            specify a value for reproducible splits, otherwise each call is unique.
-
-    See Also:
-        - :func:`sklearn.model_selection.train_test_split()`
+    Random 3-way split with optional stratification by target.
+    Preserves reproducibility with numpy RNG.
     """
     if label_fracs is None:
         label_fracs = _DEFAULT_SPLIT_LABEL_FRACS
 
-    labels = list(label_fracs.keys())
-    fracs = list(label_fracs.values())
+    labels = ["train", "validate", "test"]
+    p = np.array([label_fracs[l] for l in labels], dtype=float)
+    p = p / p.sum()
+
     rng = np.random.default_rng(seed=seed)
-    return pd.Series(
-        data=rng.choice(labels, size=len(df), p=fracs, shuffle=shuffle),
-        index=df.index,
-        dtype="string",
-        name="split",
-    )
+    split = pd.Series(index=df.index, dtype="string", name="split")
+
+    if stratify_col is None or stratify_col not in df.columns:
+        # Unstratified
+        choice = rng.choice(labels, size=len(df), p=p)
+        split[:] = choice
+        return split
+
+    # Stratified: shuffle indices within each class, then allocate
+    y = pd.Categorical(df[stratify_col])
+    for cls in y.categories:
+        idx = df.index[y == cls]
+        n = len(idx)
+        if n == 0:
+            continue
+
+        # randomize order within this class
+        idx_shuffled = rng.permutation(idx)
+
+        # split counts for this class
+        n_train = int(round(p[0] * n))
+        n_valid = int(round(p[1] * n))
+        # whatever's left goes to test
+        n_test = n - n_train - n_valid
+
+        split.loc[idx_shuffled[:n_train]] = "train"
+        split.loc[idx_shuffled[n_train : n_train + n_valid]] = "validate"
+        split.loc[idx_shuffled[n_train + n_valid :]] = "test"
+
+    return split.astype("string")
 
 
 def compute_sample_weights(

--- a/tests/modeling/test_utils.py
+++ b/tests/modeling/test_utils.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 import tomlkit
+import numpy as np
 
 from student_success_tool.modeling import utils
 
@@ -9,20 +10,20 @@ from student_success_tool.modeling import utils
     ["df", "label_fracs", "shuffle", "seed"],
     [
         (
-            pd.DataFrame(data=list(range(1000))),
-            {"train": 0.5, "test": 0.5},
+            pd.DataFrame({"x": range(1000)}),
+            {"train": 0.6, "validate": 0.2, "test": 0.2},
             True,
             10,
         ),
         (
-            pd.DataFrame(data=list(range(1000))),
-            {"train": 0.6, "test": 0.2, "valid": 0.2},
+            pd.DataFrame({"x": range(1000)}),
+            {"train": 0.6, "validate": 0.2, "test": 0.2},
             False,
             11,
         ),
         (
-            pd.DataFrame(data=list(range(1000))),
-            {"train": 0.5, "test": 0.5},
+            pd.DataFrame({"x": range(1000)}),
+            {"train": 0.5, "validate": 0.25, "test": 0.25},
             True,
             42,
         ),
@@ -30,30 +31,75 @@ from student_success_tool.modeling import utils
 )
 def test_compute_dataset_splits(df, label_fracs, shuffle, seed):
     obs = utils.compute_dataset_splits(
-        df, label_fracs=label_fracs, shuffle=shuffle, seed=seed
+        df,
+        stratify_col=None,
+        label_fracs=label_fracs,
+        shuffle=shuffle,
+        seed=seed,
     )
     assert isinstance(obs, pd.Series)
     assert len(obs) == len(df)
-    labels = list(label_fracs.keys())
-    fracs = list(label_fracs.values())
-    obs_value_counts = obs.value_counts(normalize=True)
+    assert obs.isna().sum() == 0
+    assert set(obs.unique()) <= {"train", "validate", "test"}
+
+    labels = ["train", "validate", "test"]
+    fracs = [label_fracs[l] for l in labels]
+
+    obs_value_counts = (
+        obs.value_counts(normalize=True)
+        .reindex(labels, fill_value=0.0)
+        .astype("float64")
+    )
+    # make expected index dtype match observed
+    exp_index = pd.Index(labels, dtype=obs_value_counts.index.dtype, name="split")
     exp_value_counts = pd.Series(
-        data=fracs,
-        index=pd.Index(labels, dtype="string", name="split"),
+        data=np.array(fracs) / np.sum(fracs),
+        index=exp_index,
         name="proportion",
-        dtype="Float64",
+        dtype="float64",
     )
-    assert (
-        pd.testing.assert_series_equal(
-            obs_value_counts, exp_value_counts, rtol=0.15, check_like=True
-        )
-        is None
+
+    pd.testing.assert_series_equal(
+        obs_value_counts,
+        exp_value_counts,
+        rtol=0.15,
+        check_exact=False,
+        check_names=True,
     )
+
+    # Reproducibility with same seed
     if seed is not None:
         obs2 = utils.compute_dataset_splits(
-            df, label_fracs=label_fracs, shuffle=shuffle, seed=seed
+            df,
+            stratify_col=None,
+            label_fracs=label_fracs,
+            shuffle=shuffle,
+            seed=seed,
         )
         assert obs.equals(obs2)
+
+
+def test_compute_dataset_splits_stratified_preserves_prevalence():
+    # Imbalanced target
+    n = 3000
+    rng = np.random.default_rng(7)
+    y = pd.Series(rng.choice([0, 1], size=n, p=[0.8, 0.2]), name="target")
+    df = pd.DataFrame({"x": rng.normal(size=n), "target": y})
+
+    splits = utils.compute_dataset_splits(
+        df,
+        stratify_col="target",
+        label_fracs={"train": 0.6, "validate": 0.2, "test": 0.2},
+        seed=123,
+        shuffle=True,
+    )
+
+    prev_overall = df["target"].mean()
+    prev_by_split = df.groupby(splits)["target"].mean()
+
+    # Each split’s prevalence should be close to overall (within a few points)
+    for split_name, prev in prev_by_split.items():
+        assert abs(prev - prev_overall) < 0.03  # 3 percentage points
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**compute_dataset_splits**: Added stratification. Also added using train_test_split because the performance improvement of using np.rng is only marginal. In fact using np.rng as we have been was actually a bug since we were all using the same seed and target prevalence was more in validation than test since we weren't using stratification. Especially with smaller datasets, this difference becomes magnified. In H2O, this caused validation log loss to always be artifically greater than test log loss (because it has more 1s than 0s compared to test log loss).

Also updated preprocess notebook to add the stratify column, which in our case is just our target column.

**H2O training configuration**: Removed stopping threshold and rounds since it can cause H2O training to be much slower and the performance improvement isn't a lot. Also, added nfolds to just be set to 5 which should be applicable for all of our datasets since we are mostly always under 50K rows. 

**templates**: Made some small import changes based on the last PR.

**H2O progress bar disabled**: Disabled progress bar which cleans up logs and makes things more readable.
